### PR TITLE
fix(tui): order slash commands by usage frequency

### DIFF
--- a/crates/protocol/src/slash_command.rs
+++ b/crates/protocol/src/slash_command.rs
@@ -203,22 +203,24 @@ impl FromStr for SlashCommand {
 }
 
 pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
+    // Presentation order for the TUI popup. Do not alphabetize: keep frequently used
+    // commands first so useful actions remain visible without scrolling.
     vec![
         ("model", SlashCommand::Model),
-        ("skills", SlashCommand::Skills),
-        ("mcps", SlashCommand::Mcp),
-        ("compact", SlashCommand::Compact),
-        ("resume", SlashCommand::Resume),
-        ("new", SlashCommand::New),
-        ("rename", SlashCommand::Rename),
-        ("delete", SlashCommand::Delete),
-        ("status", SlashCommand::Status),
-        ("settings", SlashCommand::Settings),
         ("permissions", SlashCommand::Permissions),
-        ("show-reasoning", SlashCommand::ShowReasoning),
+        ("status", SlashCommand::Status),
+        ("new", SlashCommand::New),
+        ("resume", SlashCommand::Resume),
+        ("compact", SlashCommand::Compact),
         ("diff", SlashCommand::Diff),
         ("goal", SlashCommand::Goal),
         ("btw", SlashCommand::Btw),
+        ("skills", SlashCommand::Skills),
+        ("mcps", SlashCommand::Mcp),
+        ("settings", SlashCommand::Settings),
+        ("rename", SlashCommand::Rename),
+        ("delete", SlashCommand::Delete),
+        ("show-reasoning", SlashCommand::ShowReasoning),
         ("exit", SlashCommand::Exit),
     ]
 }

--- a/crates/tui/src/bottom_pane/command_popup.rs
+++ b/crates/tui/src/bottom_pane/command_popup.rs
@@ -394,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    fn popup_lists_only_supported_commands() {
+    fn popup_lists_supported_commands_by_usage_frequency() {
         let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/".to_string());
 
@@ -409,20 +409,20 @@ mod tests {
             cmds,
             vec![
                 "model",
-                "skills",
-                "mcps",
-                "compact",
-                "resume",
-                "new",
-                "rename",
-                "delete",
-                "status",
-                "settings",
                 "permissions",
-                "show-reasoning",
+                "status",
+                "new",
+                "resume",
+                "compact",
                 "diff",
                 "goal",
                 "btw",
+                "skills",
+                "mcps",
+                "settings",
+                "rename",
+                "delete",
+                "show-reasoning",
                 "exit",
             ]
         );


### PR DESCRIPTION
## Summary

- prioritize frequently used slash commands in the initial eight-row TUI popup
- keep lower-frequency configuration, destructive, and exit actions later in the list
- document that the command vector defines presentation order and lock the full order with a regression test

The initial viewport now shows: model, permissions, status, new, resume, compact, diff, and goal.

## Validation

- cargo fmt --all -- --check
- cargo test -p devo-protocol slash_command::tests -- --nocapture
- cargo test -p devo-tui bottom_pane::command_popup::tests -- --nocapture

Closes #123