### PR TITLE
fix(tui): align slash Enter test with usage-frequency order

### DIFF
--- a/crates/tui/src/bottom_pane/chat_composer.rs
+++ b/crates/tui/src/bottom_pane/chat_composer.rs
@@ -3886,7 +3886,7 @@ mod reference_popup_tests {
 
         assert_eq!(
             composer.handle_key_event(press(KeyCode::Enter)),
-            (InputResult::Command(SlashCommand::Skills), true)
+            (InputResult::Command(SlashCommand::Permissions), true)
         );
         assert_eq!(composer.current_text(), "");
     }


### PR DESCRIPTION
## Summary
- Update `enter_accepts_focused_slash_command` so Down+Enter on `/` expects `/permissions`, matching the usage-frequency slash popup order from #182.

## Test plan
- [x] `cargo test -p devo-tui --lib enter_accepts_focused_slash_command`
- [x] `cargo fmt`

Made with [Cursor](https://cursor.com)