### PR TITLE
feat(desktop): add Customize gallery and restyle Settings

### DIFF
--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -52,6 +52,7 @@
         "electron": "^43.4.1",
         "electron-builder": "^26.0.0",
         "electron-vite": "^5.0.0",
+        "rcedit": "^5.0.2",
         "shiki": "^3.22.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
@@ -867,6 +868,8 @@
     "cross-dirname": ["cross-dirname@0.1.0", "https://registry.npmmirror.com/cross-dirname/-/cross-dirname-0.1.0.tgz", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
 
     "cssesc": ["cssesc@3.0.0", "https://registry.npmmirror.com/cssesc/-/cssesc-3.0.0.tgz", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
@@ -1764,6 +1767,8 @@
 
     "raw-body": ["raw-body@3.0.2", "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.2.tgz", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "rcedit": ["rcedit@5.0.2", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-dgysxaeXZ4snLpPjn8aVtHvZDCx+aRcvZbaWBgl1poU6OPustMvOkj9a9ZqASQ6i5Y5szJ13LSvglEOwrmgUxA=="],
+
     "react": ["react@19.2.7", "https://registry.npmmirror.com/react/-/react-19.2.7.tgz", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-day-picker": ["react-day-picker@9.14.0", "https://registry.npmmirror.com/react-day-picker/-/react-day-picker-9.14.0.tgz", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
@@ -2250,6 +2255,10 @@
 
     "cross-spawn/which": ["which@2.0.2", "https://registry.npmmirror.com/which/-/which-2.0.2.tgz", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "cross-spawn-windows-exe/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "cross-spawn-windows-exe/which": ["which@2.0.2", "https://registry.npmmirror.com/which/-/which-2.0.2.tgz", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "https://registry.npmmirror.com/cose-base/-/cose-base-2.2.0.tgz", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
     "d3-dsv/commander": ["commander@7.2.0", "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -2379,6 +2388,8 @@
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "app-builder-lib/which/isexe": ["isexe@3.1.5", "https://registry.npmmirror.com/isexe/-/isexe-3.1.5.tgz", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "cross-spawn-windows-exe/which/isexe": ["isexe@2.0.0", "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -28,6 +28,8 @@ extraResources:
     to: iconTemplate@2x.png
   - from: resources/icon.png
     to: icon.png
+  - from: resources/icon.ico
+    to: icon.ico
   - from: resources/icon-macos.png
     to: icon-macos.png
   - from: resources/iconTray.png

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -106,6 +106,7 @@
 		"electron": "^43.4.1",
 		"electron-builder": "^26.0.0",
 		"electron-vite": "^5.0.0",
+		"rcedit": "^5.0.2",
 		"shiki": "^3.22.0",
 		"tailwindcss": "^4.0.0",
 		"typescript": "^5.7.0",

--- a/apps/desktop/packages/devo-ai-sdk/src/v2/client-native-interactions.test.ts
+++ b/apps/desktop/packages/devo-ai-sdk/src/v2/client-native-interactions.test.ts
@@ -38,6 +38,10 @@ class FakeNativeTransport implements DevoNativeTransport {
 				return { skills: [{ ...nativeSkill, enabled: false }] }
 			case "mcp/list":
 				return { servers: [{ name: "docs", status: "connected", toolCount: 2 }] }
+			case "mcp/tools":
+				return {
+					tools: [{ name: "get_time", description: "Current time" }],
+				}
 			case "workspace/changes/read":
 				return { views: [nativeWorkspaceView] }
 			case "turn/start":
@@ -272,6 +276,9 @@ describe("Native desktop SDK interactions", () => {
 		expect((await client.mcp.list()).data).toEqual([
 			{ name: "docs", status: "connected", toolCount: 2 },
 		])
+		expect((await client.mcp.tools({ name: "docs" })).data).toEqual([
+			{ name: "get_time", description: "Current time" },
+		])
 		expect((await client.app.setSkillEnabled({ path: "/skills/review", enabled: false })).data).toEqual([
 			{ ...nativeSkill, enabled: false },
 		])
@@ -285,6 +292,7 @@ describe("Native desktop SDK interactions", () => {
 				directory: "/repo",
 			},
 			{ method: "mcp/list", params: {}, directory: "/repo" },
+			{ method: "mcp/tools", params: { name: "docs" }, directory: "/repo" },
 			{
 				method: "skill/set_enabled",
 				params: { path: "/skills/review", enabled: false, cwd: "/repo" },

--- a/apps/desktop/packages/devo-ai-sdk/src/v2/protocol-validation.test.ts
+++ b/apps/desktop/packages/devo-ai-sdk/src/v2/protocol-validation.test.ts
@@ -182,6 +182,27 @@ describe("desktop protocol runtime validation", () => {
 		).toBe(payload)
 	})
 
+	test("validates mcp tools requests and results", () => {
+		const requestPayload = { name: "docs" }
+		const resultPayload = {
+			tools: [{ name: "get_time", description: "Current time" }],
+		}
+		expect(
+			assertValidProtocolPayload({
+				direction: "outgoingRequest",
+				method: "mcp/tools",
+				payload: requestPayload,
+			}),
+		).toBe(requestPayload)
+		expect(
+			assertValidProtocolPayload({
+				direction: "incomingResult",
+				method: "mcp/tools",
+				payload: resultPayload,
+			}),
+		).toBe(resultPayload)
+	})
+
 	test("rejects unknown protocol methods", () => {
 		expect(() =>
 			assertValidProtocolPayload({

--- a/apps/desktop/scripts/brand-electron-dev.mjs
+++ b/apps/desktop/scripts/brand-electron-dev.mjs
@@ -1,45 +1,94 @@
 import { execFileSync } from "node:child_process"
-import { copyFileSync, existsSync, mkdirSync, utimesSync } from "node:fs"
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync, utimesSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
-if (process.platform !== "darwin") {
-	process.exit(0)
-}
-
 const appName = "Devo"
-const bundleIdentifier = "com.devo.desktop.dev"
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const desktopDir = dirname(scriptDir)
-const electronAppPath = join(desktopDir, "node_modules/electron/dist/Electron.app")
-const plistPath = join(electronAppPath, "Contents/Info.plist")
-const iconSourcePath = join(desktopDir, "resources/icon.icns")
-const iconTargetPath = join(electronAppPath, "Contents/Resources/electron.icns")
 
-if (!existsSync(plistPath) || !existsSync(iconSourcePath)) {
-	process.exit(0)
+function brandDarwin() {
+	const bundleIdentifier = "com.devo.desktop.dev"
+	const electronAppPath = join(desktopDir, "node_modules/electron/dist/Electron.app")
+	const plistPath = join(electronAppPath, "Contents/Info.plist")
+	const iconSourcePath = join(desktopDir, "resources/icon.icns")
+	const iconTargetPath = join(electronAppPath, "Contents/Resources/electron.icns")
+
+	if (!existsSync(plistPath) || !existsSync(iconSourcePath)) {
+		return
+	}
+
+	function setPlistString(key, value) {
+		try {
+			execFileSync("/usr/libexec/PlistBuddy", ["-c", `Set :${key} ${value}`, plistPath], {
+				stdio: "ignore",
+			})
+		} catch {
+			execFileSync("/usr/libexec/PlistBuddy", ["-c", `Add :${key} string ${value}`, plistPath], {
+				stdio: "ignore",
+			})
+		}
+	}
+
+	mkdirSync(dirname(iconTargetPath), { recursive: true })
+	copyFileSync(iconSourcePath, iconTargetPath)
+	setPlistString("CFBundleName", appName)
+	setPlistString("CFBundleDisplayName", appName)
+	setPlistString("CFBundleIdentifier", bundleIdentifier)
+	setPlistString("CFBundleIconFile", "electron.icns")
+
+	const now = new Date()
+	utimesSync(electronAppPath, now, now)
+
+	console.log(`Branded Electron dev app as ${appName}`)
 }
 
-function setPlistString(key, value) {
+async function brandWin32() {
+	const electronExePath = join(desktopDir, "node_modules/electron/dist/electron.exe")
+	const iconSourcePath = join(desktopDir, "resources/icon.ico")
+	const brandedExePath = `${electronExePath}.branded`
+
+	if (!existsSync(electronExePath) || !existsSync(iconSourcePath)) {
+		return
+	}
+
+	const { rcedit } = await import("rcedit")
+	copyFileSync(electronExePath, brandedExePath)
 	try {
-		execFileSync("/usr/libexec/PlistBuddy", ["-c", `Set :${key} ${value}`, plistPath], {
-			stdio: "ignore",
+		await rcedit(brandedExePath, {
+			icon: iconSourcePath,
+			"version-string": {
+				CompanyName: "Devo",
+				FileDescription: appName,
+				InternalName: appName,
+				OriginalFilename: "electron.exe",
+				ProductName: appName,
+			},
 		})
-	} catch {
-		execFileSync("/usr/libexec/PlistBuddy", ["-c", `Add :${key} string ${value}`, plistPath], {
-			stdio: "ignore",
-		})
+		try {
+			renameSync(brandedExePath, electronExePath)
+		} catch {
+			console.warn(
+				"Could not replace electron.exe while it is running. Close the Desktop client, then run `bun run brand:electron-dev` again.",
+			)
+			return
+		}
+	} finally {
+		if (existsSync(brandedExePath)) {
+			unlinkSync(brandedExePath)
+		}
+	}
+
+	console.log(`Branded Electron.exe for Windows as ${appName}`)
+}
+
+if (process.platform === "darwin") {
+	brandDarwin()
+} else if (process.platform === "win32") {
+	try {
+		await brandWin32()
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`Skipping Windows Electron branding: ${message}`)
 	}
 }
-
-mkdirSync(dirname(iconTargetPath), { recursive: true })
-copyFileSync(iconSourcePath, iconTargetPath)
-setPlistString("CFBundleName", appName)
-setPlistString("CFBundleDisplayName", appName)
-setPlistString("CFBundleIdentifier", bundleIdentifier)
-setPlistString("CFBundleIconFile", "electron.icns")
-
-const now = new Date()
-utimesSync(electronAppPath, now, now)
-
-console.log(`Branded Electron dev app as ${appName}`)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -30,6 +30,12 @@ let isQuitting = false
 app.setName(appName)
 process.title = appName
 
+// Windows taskbar / jump-list identity. Without this, Windows may group the app
+// with other Electron apps and keep showing the default Electron icon.
+if (process.platform === "win32") {
+	app.setAppUserModelId(app.isPackaged ? "com.devo.desktop" : "com.devo.desktop.dev")
+}
+
 // ESM equivalent for __dirname
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -282,15 +288,21 @@ async function createWindow(): Promise<BrowserWindow> {
 	// Resolve the window icon for Linux/Windows. macOS uses the .app bundle icon.
 	// Linux: use 256x256 icon — GTK's GdkPixbuf can choke on the full 1024x1024
 	// icon on Wayland, causing GDK_IS_PIXBUF assertion failures.
+	// Windows: prefer .ico for best taskbar / title-bar visual quality.
 	const windowIcon = isMac
 		? undefined
 		: app.isPackaged
-			? path.join(process.resourcesPath, "icon.png")
+			? path.join(
+					process.resourcesPath,
+					process.platform === "win32" ? "icon.ico" : "icon.png",
+				)
 			: path.join(
 					__dirname,
 					process.platform === "linux"
 						? "../../resources/linux-icons/256x256.png"
-						: "../../resources/icon.png",
+						: process.platform === "win32"
+							? "../../resources/icon.ico"
+							: "../../resources/icon.png",
 				)
 
 	const win = new BrowserWindow({
@@ -320,6 +332,15 @@ async function createWindow(): Promise<BrowserWindow> {
 		},
 	})
 
+	if (windowIcon) {
+		const image = nativeImage.createFromPath(windowIcon)
+		if (image.isEmpty()) {
+			log.warn("Failed to load window icon", { windowIcon })
+		} else {
+			win.setIcon(image)
+		}
+	}
+
 	win.on("close", (event) => {
 		if (process.platform !== "win32" || isQuitting) return
 
@@ -330,6 +351,10 @@ async function createWindow(): Promise<BrowserWindow> {
 	// Show the window once the renderer has painted — avoids a flash of
 	// transparent/blank content while the page loads.
 	win.once("ready-to-show", () => {
+		if (windowIcon) {
+			const image = nativeImage.createFromPath(windowIcon)
+			if (!image.isEmpty()) win.setIcon(image)
+		}
 		win.show()
 	})
 

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -44,7 +44,9 @@ import {
 	restoreMigrationBackup,
 	scanProvider,
 } from "./onboarding"
+import { openUserMcpConfigFile } from "./mcp-config"
 import { getOpenInTargets, openInTarget, setPreferredTarget } from "./open-in-targets"
+import { MCP_CONFIG_OPEN_PATH } from "../shared/mcp-config"
 import {
 	ensureServer,
 	getNativeTrafficLogState,
@@ -446,6 +448,11 @@ export function registerIpcHandlers(): void {
 		withLogging("rules:create", (_, directory: string) => createProjectAgentsMd(directory)),
 	)
 
+	ipcMain.handle(
+		"mcp:open-config",
+		withLogging("mcp:open-config", async () => await openUserMcpConfigFile()),
+	)
+
 	// --- Fetch proxy (bypasses Chromium connection limits) ---
 
 	ipcMain.handle("fetch:request", withLogging("fetch:request", handleFetchProxy))
@@ -458,8 +465,12 @@ export function registerIpcHandlers(): void {
 		"open-in:open",
 		withLogging(
 			"open-in:open",
-			async (_, directory: string, targetId: string, persistPreferred?: boolean) =>
-				await openInTarget(directory, targetId, { persistPreferred }),
+			async (_, directory: string, targetId: string, persistPreferred?: boolean) => {
+				if (directory === MCP_CONFIG_OPEN_PATH) {
+					return await openUserMcpConfigFile()
+				}
+				await openInTarget(directory, targetId, { persistPreferred })
+			},
 		),
 	)
 

--- a/apps/desktop/src/main/mcp-config.test.ts
+++ b/apps/desktop/src/main/mcp-config.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, describe, expect, mock, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+mock.module("electron", () => ({
+	shell: {
+		openPath: async () => "",
+	},
+}))
+
+mock.module("./settings-store", () => ({
+	getSettings: () => ({ openIn: { preferredTargetId: null } }),
+	updateSettings: () => ({}),
+}))
+
+mock.module("./open-in-targets", () => ({
+	getOpenInTargets: async () => ({
+		targets: [],
+		availableTargets: [],
+		preferredTarget: null,
+	}),
+	openInTarget: async () => ({ success: true }),
+}))
+
+const { ensureUserMcpConfigFile, userMcpConfigPath } = await import("./mcp-config")
+const { MCP_CONFIG_OPEN_PATH } = await import("../shared/mcp-config")
+
+function withTempDir(run: (dir: string) => void): void {
+	const dir = mkdtempSync(join(tmpdir(), "devo-mcp-config-"))
+	try {
+		run(dir)
+	} finally {
+		rmSync(dir, { recursive: true, force: true })
+	}
+}
+
+describe("user MCP config file", () => {
+	test("resolves config.toml under the Devo home directory", () => {
+		expect(userMcpConfigPath(join("home", ".devo"))).toBe(join("home", ".devo", "config.toml"))
+	})
+
+	test("creates a stub config.toml when the file is missing", () => {
+		withTempDir((dir) => {
+			const configPath = userMcpConfigPath(dir)
+			ensureUserMcpConfigFile(configPath)
+			expect(existsSync(configPath)).toBe(true)
+			const body = readFileSync(configPath, "utf-8")
+			expect(body).toContain("[mcp_servers.<id>]")
+			expect(body).toContain('command = "npx"')
+		})
+	})
+
+	test("does not overwrite an existing config.toml", () => {
+		withTempDir((dir) => {
+			const configPath = userMcpConfigPath(dir)
+			writeFileSync(configPath, "theme = \"aurora\"\n", "utf-8")
+			ensureUserMcpConfigFile(configPath)
+			expect(readFileSync(configPath, "utf-8")).toBe("theme = \"aurora\"\n")
+		})
+	})
+
+	test("uses a stable sentinel path for the existing openIn preload bridge", () => {
+		expect(MCP_CONFIG_OPEN_PATH).toBe("devo-mcp-config")
+	})
+})
+
+afterAll(() => {
+	mock.restore()
+})

--- a/apps/desktop/src/main/mcp-config.ts
+++ b/apps/desktop/src/main/mcp-config.ts
@@ -1,0 +1,54 @@
+/**
+ * User-level MCP config file (`~/.devo/config.toml`) helpers.
+ * The Customize MCPs "+" action opens this file in the preferred editor.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { shell } from "electron"
+import { findDevoHome } from "./native-traffic-log"
+import { getOpenInTargets, openInTarget } from "./open-in-targets"
+
+export const MCP_CONFIG_FILE_NAME = "config.toml"
+
+const MCP_CONFIG_STUB = `\
+# Devo user configuration
+# Add MCP servers under [mcp_servers.<id>]. Example:
+#
+# [mcp_servers.time]
+# command = "npx"
+# args = ["-y", "mcp-server-time"]
+#
+
+`
+
+export function userMcpConfigPath(devoHome: string): string {
+	return join(devoHome, MCP_CONFIG_FILE_NAME)
+}
+
+export function ensureUserMcpConfigFile(configPath: string): void {
+	const parent = dirname(configPath)
+	mkdirSync(parent, { recursive: true })
+	if (!existsSync(configPath)) {
+		writeFileSync(configPath, MCP_CONFIG_STUB, "utf-8")
+	}
+}
+
+/**
+ * Ensures the user config file exists, then opens it with the General
+ * settings "Default open destination" app (fallback: OS file handler).
+ */
+export async function openUserMcpConfigFile(): Promise<{ path: string }> {
+	const configPath = userMcpConfigPath(findDevoHome())
+	ensureUserMcpConfigFile(configPath)
+
+	const { preferredTarget } = await getOpenInTargets()
+	if (preferredTarget) {
+		await openInTarget(configPath, preferredTarget)
+	} else {
+		const error = await shell.openPath(configPath)
+		if (error) throw new Error(error)
+	}
+
+	return { path: configPath }
+}

--- a/apps/desktop/src/main/native-stdio-client.test.ts
+++ b/apps/desktop/src/main/native-stdio-client.test.ts
@@ -1,6 +1,11 @@
 import path from "node:path"
 import { describe, expect, test } from "bun:test"
-import { StdioNativeClient, buildServerProcessEnv, routeNativeLine } from "./native-stdio-client"
+import {
+	StdioNativeClient,
+	buildServerProcessEnv,
+	requestTimeoutMsForMethod,
+	routeNativeLine,
+} from "./native-stdio-client"
 
 describe("routeNativeLine", () => {
 	test("routes JSON-RPC responses, notifications, and server requests", () => {
@@ -170,6 +175,18 @@ describe("StdioNativeClient", () => {
 		await expect(client.request("initialize")).rejects.toThrow("write EPIPE")
 		expect((client as unknown as { pending: Map<unknown, unknown> }).pending.size).toBe(0)
 		expect(client.connected()).toBe(false)
+	})
+
+	test("gives MCP admin RPCs a longer timeout than ordinary requests", () => {
+		expect({
+			sessionList: requestTimeoutMsForMethod("session/list", 10_000),
+			mcpTools: requestTimeoutMsForMethod("mcp/tools", 10_000),
+			mcpSetEnabled: requestTimeoutMsForMethod("mcp/set_enabled", 5),
+		}).toEqual({
+			sessionList: 10_000,
+			mcpTools: 60_000,
+			mcpSetEnabled: 60_000,
+		})
 	})
 
 	test("times out ordinary RPCs with the method and request id", async () => {

--- a/apps/desktop/src/main/native-stdio-client.ts
+++ b/apps/desktop/src/main/native-stdio-client.ts
@@ -33,6 +33,15 @@ type PendingRequest = {
 }
 
 const REQUEST_TIMEOUT_MS = 10_000
+/** MCP admin RPCs may start a lazy server before listing tools. */
+export const MCP_ADMIN_REQUEST_TIMEOUT_MS = 60_000
+
+export function requestTimeoutMsForMethod(method: string, fallbackMs: number): number {
+	if (method === "mcp/tools" || method === "mcp/set_enabled") {
+		return Math.max(fallbackMs, MCP_ADMIN_REQUEST_TIMEOUT_MS)
+	}
+	return fallbackMs
+}
 
 export type NativeIncomingMessage =
 	| { type: "response"; id: JsonRpcId; message: Record<string, unknown> }
@@ -290,7 +299,7 @@ export class StdioNativeClient implements NativeTransport {
 				if (!this.pending.delete(id)) return
 				this.pendingMethods.delete(id)
 				reject(new Error(`${method} request ${id} timed out`))
-			}, this.options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS)
+			}, requestTimeoutMsForMethod(method, this.options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS))
 			this.pending.set(id, { resolve, reject, timer })
 		})
 		this.pendingMethods.set(id, method)

--- a/apps/desktop/src/preload/api.d.ts
+++ b/apps/desktop/src/preload/api.d.ts
@@ -536,6 +536,7 @@ export interface DevoAPI {
 		getTargets: () => Promise<OpenInTargetsResult>
 		open: (directory: string, targetId: string, persistPreferred?: boolean) => Promise<void>
 		setPreferred: (targetId: string) => Promise<{ success: boolean }>
+		openMcpConfig?: () => Promise<{ path: string }>
 	}
 
 	// Native theme (syncs OS chrome to app color scheme)
@@ -554,6 +555,9 @@ export interface DevoAPI {
 		list: (directories: string[]) => Promise<RuleFileInfo[]>
 		open: (filePath: string) => Promise<void>
 		create: (directory: string) => Promise<RuleFileInfo>
+	}
+	mcp?: {
+		openConfig: () => Promise<{ path: string }>
 	}
 	desktopFolders: {
 		stat: (directories: string[]) => Promise<DesktopFolderStat[]>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -198,6 +198,7 @@ contextBridge.exposeInMainWorld("devo", {
 		open: (directory: string, targetId: string, persistPreferred?: boolean) =>
 			ipcRenderer.invoke("open-in:open", directory, targetId, persistPreferred),
 		setPreferred: (targetId: string) => ipcRenderer.invoke("open-in:set-preferred", targetId),
+		openMcpConfig: () => ipcRenderer.invoke("mcp:open-config"),
 	},
 
 	// --- Native theme (syncs OS chrome to app color scheme) ---
@@ -226,6 +227,10 @@ contextBridge.exposeInMainWorld("devo", {
 		list: (directories: string[]) => ipcRenderer.invoke("rules:list", directories),
 		open: (filePath: string) => ipcRenderer.invoke("rules:open", filePath),
 		create: (directory: string) => ipcRenderer.invoke("rules:create", directory),
+	},
+
+	mcp: {
+		openConfig: () => ipcRenderer.invoke("mcp:open-config"),
 	},
 
 	desktopFolders: {

--- a/apps/desktop/src/renderer/atoms/derived/agents.test.ts
+++ b/apps/desktop/src/renderer/atoms/derived/agents.test.ts
@@ -175,4 +175,41 @@ describe("sidebar project list", () => {
 		expect(directories).toContain("/repo/alpha")
 		expect(directories).toContain("/repo/beta")
 	})
+
+	test("drops a directory from the sidebar when it leaves both desktop folders and discovery", () => {
+		const directory = "/repo/remove-folder"
+		appStore.set(desktopFoldersAtom, [
+			{ id: "desktop-folder-remove", directory, name: "remove-folder", addedAt: 1 },
+		])
+		appStore.set(discoveryAtom, {
+			loaded: true,
+			loading: false,
+			error: null,
+			phase: "ready",
+			projects: [
+				{
+					id: "remove-id",
+					name: "remove-folder",
+					worktree: directory,
+					path: { root: directory },
+					time: { created: 1, updated: 1 },
+					sandboxes: [],
+				},
+			],
+		})
+
+		expect(appStore.get(projectListAtom).map((item) => item.directory)).toContain(directory)
+
+		appStore.set(desktopFoldersAtom, [])
+		expect(appStore.get(projectListAtom).map((item) => item.directory)).toContain(directory)
+
+		appStore.set(discoveryAtom, {
+			loaded: true,
+			loading: false,
+			error: null,
+			phase: "ready",
+			projects: [],
+		})
+		expect(appStore.get(projectListAtom).map((item) => item.directory)).not.toContain(directory)
+	})
 })

--- a/apps/desktop/src/renderer/components/settings/about-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/about-settings.tsx
@@ -2,6 +2,7 @@ import { Button } from "@devo/ui/components/button"
 import { DownloadIcon, Loader2Icon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useUpdater } from "../../hooks/use-updater"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -22,10 +23,8 @@ export function AboutSettings() {
 	}, [])
 
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">About</h2>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader title="About" />
 
 			<SettingsSection>
 				<SettingsRow label="Version" description={isDev ? "Development build" : undefined}>

--- a/apps/desktop/src/renderer/components/settings/general-settings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/general-settings.test.tsx
@@ -21,11 +21,20 @@ mock.module("@devo/ui/components/select", () => ({
 	SelectContent: ({ children }: { children: React.ReactNode }) => (
 		<div data-slot="select-content">{children}</div>
 	),
+	SelectGroup: ({ children }: { children: React.ReactNode }) => (
+		<div data-slot="select-group">{children}</div>
+	),
 	SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
 		<div data-slot="select-item" data-value={value}>
 			{children}
 		</div>
 	),
+	SelectLabel: ({ children }: { children: React.ReactNode }) => (
+		<div data-slot="select-label">{children}</div>
+	),
+	SelectScrollDownButton: () => null,
+	SelectScrollUpButton: () => null,
+	SelectSeparator: () => <hr />,
 	SelectTrigger: ({ children }: { children: React.ReactNode }) => (
 		<button type="button" data-slot="select-trigger">
 			{children}
@@ -54,6 +63,7 @@ describe("GeneralSettings", () => {
 			hasVerboseMode: markup.includes(">Verbose</div>") || markup.includes(">Verbose<"),
 			hasConversation: markup.includes(">Conversation</h3>"),
 			hasHideThinking: markup.includes(">Hide thinking while working</label>"),
+			hasHomepageTitle: markup.includes("text-[32px] font-normal leading-tight tracking-[-0.03em]"),
 		}).toEqual({
 			hasAppearance: true,
 			hasTheme: true,
@@ -62,6 +72,7 @@ describe("GeneralSettings", () => {
 			hasVerboseMode: true,
 			hasConversation: true,
 			hasHideThinking: true,
+			hasHomepageTitle: true,
 		})
 	})
 })

--- a/apps/desktop/src/renderer/components/settings/general-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/general-settings.tsx
@@ -14,6 +14,7 @@ import { useDisplayMode, useHideThinkingWhileWorking, useSetDisplayMode, useSetH
 import { useColorScheme, useSetColorScheme } from "../../hooks/use-theme"
 import type { ColorScheme } from "../../lib/themes"
 import { fetchOpenInTargets, setOpenInPreferred } from "../../services/backend"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -21,14 +22,10 @@ const isElectron = typeof window !== "undefined" && "devo" in window
 
 export function GeneralSettings() {
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">General</h2>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader title="General" />
 
-			<SettingsSection>
-				<OpenDestinationRow />
-			</SettingsSection>
+			<OpenDestinationRow />
 
 			<SettingsSection title="Appearance">
 				<ThemeRow />
@@ -63,28 +60,30 @@ function OpenDestinationRow() {
 	if (targets.length === 0) return null
 
 	return (
-		<SettingsRow
-			label="Default open destination"
-			description="Where files and folders open by default"
-		>
-			<Select
-				value={preferred ?? undefined}
-				onValueChange={(v) => {
-					if (v !== null) handleChange(v)
-				}}
+		<SettingsSection>
+			<SettingsRow
+				label="Default open destination"
+				description="Where files and folders open by default"
 			>
-				<SelectTrigger className="min-w-[180px]">
-					<SelectValue placeholder="Select..." />
-				</SelectTrigger>
-				<SelectContent>
-					{targets.map((t) => (
-						<SelectItem key={t.id} value={t.id}>
-							{t.label}
-						</SelectItem>
-					))}
-				</SelectContent>
-			</Select>
-		</SettingsRow>
+				<Select
+					value={preferred ?? undefined}
+					onValueChange={(v) => {
+						if (v !== null) handleChange(v)
+					}}
+				>
+					<SelectTrigger className="min-w-[180px]">
+						<SelectValue placeholder="Select..." />
+					</SelectTrigger>
+					<SelectContent>
+						{targets.map((t) => (
+							<SelectItem key={t.id} value={t.id}>
+								{t.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</SettingsRow>
+		</SettingsSection>
 	)
 }
 
@@ -100,7 +99,7 @@ function ThemeRow() {
 
 	return (
 		<SettingsRow label="Theme" description="Use light, dark, or match your system">
-			<div className="flex items-center rounded-md border border-border">
+			<div className="flex items-center rounded-md border border-border/40">
 				{options.map((opt) => {
 					const Icon = opt.icon
 					const isActive = colorScheme === opt.value
@@ -109,13 +108,13 @@ function ThemeRow() {
 							key={opt.value}
 							type="button"
 							onClick={() => setColorScheme(opt.value)}
-							className={`flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors first:rounded-l-md last:rounded-r-md ${
+							className={`flex items-center gap-1.5 px-2.5 py-1 text-[13px] transition-colors first:rounded-l-md last:rounded-r-md ${
 								isActive
-									? "bg-accent text-accent-foreground font-medium"
-									: "text-muted-foreground hover:text-foreground"
+									? "bg-muted/80 text-foreground"
+									: "text-muted-foreground/60 hover:text-muted-foreground"
 							}`}
 						>
-							<Icon aria-hidden="true" className="size-3.5" />
+							<Icon aria-hidden="true" className="size-3.5 stroke-[1.5]" />
 							{opt.label}
 						</button>
 					)

--- a/apps/desktop/src/renderer/components/settings/mcp-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/mcp-settings.tsx
@@ -8,13 +8,18 @@ import { Button } from "@devo/ui/components/button"
 import { Switch } from "@devo/ui/components/switch"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
-import { PlugIcon, RefreshCwIcon } from "lucide-react"
+import { PlugIcon, PlusIcon, RefreshCwIcon } from "lucide-react"
 import { useState } from "react"
+import { toast } from "sonner"
 import { serverConnectedAtom } from "../../atoms/connection"
 import { discoveryAtom } from "../../atoms/discovery"
+import { openMcpConfigFile } from "../../services/backend"
 import { getBaseClient, getProjectClient } from "../../services/connection-manager"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
+
+const isElectron = typeof window !== "undefined" && "devo" in window
 
 interface McpServerRow {
 	name: string
@@ -25,6 +30,10 @@ interface McpServerRow {
 interface McpToolRow {
 	name: string
 	description: string
+}
+
+function mcpServerEnabled(status: string): boolean {
+	return status !== "disabled"
 }
 
 function useMcpClient() {
@@ -45,6 +54,7 @@ export function McpSettings({
 	const { client, connected, directory } = useMcpClient()
 	const queryClient = useQueryClient()
 	const [expanded, setExpanded] = useState<string | null>(null)
+	const [openingConfig, setOpeningConfig] = useState(false)
 
 	const { data: servers = [], isLoading, error, refetch } = useQuery({
 		queryKey: ["mcp-servers", directory],
@@ -60,15 +70,22 @@ export function McpSettings({
 		enabled: connected && !!client,
 	})
 
-	const { data: tools = [] } = useQuery({
+	const {
+		data: tools = [],
+		isLoading: toolsLoading,
+		error: toolsError,
+	} = useQuery({
 		queryKey: ["mcp-tools", directory, expanded],
 		queryFn: async (): Promise<McpToolRow[]> => {
 			if (!client || !expanded) return []
 			const result = await client.mcp.tools({ name: expanded })
-			return ((result.data ?? []) as Array<Record<string, unknown>>).map((tool) => ({
+			const rows = Array.isArray(result.data) ? result.data : []
+			const mapped = (rows as Array<Record<string, unknown>>).map((tool) => ({
 				name: String(tool.name ?? ""),
 				description: String(tool.description ?? ""),
 			}))
+			void queryClient.invalidateQueries({ queryKey: ["mcp-servers"] })
+			return mapped
 		},
 		enabled: connected && !!client && !!expanded,
 	})
@@ -80,8 +97,26 @@ export function McpSettings({
 		},
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["mcp-servers"] })
+			void queryClient.invalidateQueries({ queryKey: ["mcp-tools"] })
 		},
 	})
+
+	const openMcpConfig = async () => {
+		if (!isElectron) {
+			toast.error("MCP config can only be edited in the desktop app")
+			return
+		}
+		setOpeningConfig(true)
+		try {
+			await openMcpConfigFile()
+		} catch (err) {
+			toast.error("Failed to open MCP config", {
+				description: err instanceof Error ? err.message : String(err),
+			})
+		} finally {
+			setOpeningConfig(false)
+		}
+	}
 
 	const visibleServers = servers.filter((server) => {
 		if (!searchQuery) return true
@@ -89,20 +124,38 @@ export function McpSettings({
 		return haystack.includes(searchQuery.toLowerCase())
 	})
 
+	const addButton = (
+		<Button
+			type="button"
+			size="sm"
+			variant="secondary"
+			className="h-8 rounded-full px-3"
+			disabled={openingConfig}
+			onClick={() => void openMcpConfig()}
+			aria-label="Add MCP"
+		>
+			<PlusIcon className="size-3.5 stroke-[1.5]" />
+			Add
+		</Button>
+	)
+
 	return (
-		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-8"}>
+		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-10"}>
 			{!embedded && (
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">MCP</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Connect Model Context Protocol servers. Add new servers with{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-xs">devo mcp add</code>, then enable
-					them here.
-				</p>
-			</div>
+				<SettingsHeader
+					title="MCP"
+					action={addButton}
+					description={
+						<>
+							Connect Model Context Protocol servers. Add servers in{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">config.toml</code>, then
+							enable them here.
+						</>
+					}
+				/>
 			)}
 
-			<SettingsSection title="Servers">
+			<SettingsSection title="Servers" action={embedded ? addButton : undefined}>
 				{isLoading && (
 					<SettingsRow label="Loading" description="Fetching MCP server status">
 						<RefreshCwIcon className="size-4 animate-spin text-muted-foreground" />
@@ -120,7 +173,7 @@ export function McpSettings({
 						label={servers.length === 0 ? "No MCP servers" : "No matching servers"}
 						description={
 							servers.length === 0
-								? "Add a server with the CLI, then restart the session."
+								? "Add a server with +, then restart the session."
 								: "Try a different search."
 						}
 					>
@@ -128,34 +181,56 @@ export function McpSettings({
 					</SettingsRow>
 				)}
 				{visibleServers.map((server) => {
-					const enabled = server.status !== "disabled" && server.status !== "disconnected"
+					const enabled = mcpServerEnabled(server.status)
+					const expandedThis = expanded === server.name
 					return (
 						<div key={server.name}>
 							<SettingsRow
 								label={server.name}
-								description={`${server.status} · ${server.toolCount} tools`}
+								description={
+									enabled ? `${server.status} · ${server.toolCount} tools` : server.status
+								}
 							>
 								<div className="flex items-center gap-2">
 									<Badge variant="secondary">{server.status}</Badge>
-									<Button
-										size="sm"
-										variant="ghost"
-										onClick={() => setExpanded((current) => (current === server.name ? null : server.name))}
-									>
-										Tools
-									</Button>
+									{enabled && (
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() =>
+												setExpanded((current) => (current === server.name ? null : server.name))
+											}
+										>
+											Tools
+										</Button>
+									)}
 									<Switch
 										checked={enabled}
-										onCheckedChange={(checked) =>
-											toggle.mutate({ name: server.name, enabled: checked === true })
-										}
+										onCheckedChange={(checked) => {
+											const nextEnabled = checked === true
+											if (!nextEnabled) {
+												setExpanded((current) => (current === server.name ? null : current))
+											}
+											toggle.mutate({ name: server.name, enabled: nextEnabled })
+										}}
 									/>
 								</div>
 							</SettingsRow>
-							{expanded === server.name && (
-								<div className="space-y-1 px-4 pb-3 text-sm text-muted-foreground">
-									{tools.length === 0 ? (
-										<p>No tools reported yet.</p>
+							{enabled && expandedThis && (
+								<div className="space-y-1 px-5 pb-3.5 text-[13px] leading-5 text-muted-foreground">
+									{toolsError ? (
+										<p>Failed to load tools: {String(toolsError)}</p>
+									) : toolsLoading ? (
+										<p className="flex items-center gap-2">
+											<RefreshCwIcon className="size-3.5 animate-spin" />
+											Loading tools…
+										</p>
+									) : tools.length === 0 ? (
+										<p>
+											{server.status === "failed"
+												? "Server failed to start, so no tools are available."
+												: "No tools advertised."}
+										</p>
 									) : (
 										tools.map((tool) => (
 											<div key={tool.name}>

--- a/apps/desktop/src/renderer/components/settings/mcp-skill-settings.test.ts
+++ b/apps/desktop/src/renderer/components/settings/mcp-skill-settings.test.ts
@@ -10,6 +10,8 @@ const sidebarSource = readFileSync(new URL("../sidebar/app-sidebar-content.tsx",
 const layoutSource = readFileSync(new URL("../sidebar-layout.tsx", import.meta.url), "utf8")
 const routerSource = readFileSync(new URL("../../router.tsx", import.meta.url), "utf8")
 const menuSource = readFileSync(new URL("../../../main/index.ts", import.meta.url), "utf8")
+const ipcSource = readFileSync(new URL("../../../main/ipc-handlers.ts", import.meta.url), "utf8")
+const preloadSource = readFileSync(new URL("../../../preload/index.ts", import.meta.url), "utf8")
 
 describe("Desktop MCP and Skills settings", () => {
 	test("registers MCP and Skills settings tabs and routes", () => {
@@ -17,21 +19,32 @@ describe("Desktop MCP and Skills settings", () => {
 			mcpTab: settingsPageSource.includes('id: "mcp"') && settingsPageSource.includes('label: "MCP"'),
 			skillsTab:
 				settingsPageSource.includes('id: "skills"') && settingsPageSource.includes('label: "Skills"'),
+			settingsNavUsesTopActionRow:
+				settingsPageSource.includes("TopActionRow") &&
+				settingsPageSource.includes("sidebarPrimaryIconClass") &&
+				!settingsPageSource.includes("SidebarMenuButton"),
 			mcpRoute: routerSource.includes('path: "mcp"') && routerSource.includes("McpSettings"),
 			skillsRoute: routerSource.includes('path: "skills"') && routerSource.includes("SkillSettings"),
 			listsMcp: mcpSource.includes("client.mcp.list()"),
 			togglesMcp: mcpSource.includes("client.mcp.setEnabled"),
 			listsMcpTools: mcpSource.includes("client.mcp.tools"),
+			hidesToolsWhenDisabled: mcpSource.includes("mcpServerEnabled") && mcpSource.includes("{enabled && ("),
+			opensMcpConfig: mcpSource.includes("openMcpConfigFile()"),
+			addsMcpButton: mcpSource.includes('aria-label="Add MCP"'),
 			listsSkills: skillSource.includes("client.app.skills()"),
 			togglesSkills: skillSource.includes("setSkillEnabled"),
 		}).toEqual({
 			mcpTab: true,
 			skillsTab: true,
+			settingsNavUsesTopActionRow: true,
 			mcpRoute: true,
 			skillsRoute: true,
 			listsMcp: true,
 			togglesMcp: true,
 			listsMcpTools: true,
+			hidesToolsWhenDisabled: true,
+			opensMcpConfig: true,
+			addsMcpButton: true,
 			listsSkills: true,
 			togglesSkills: true,
 		})
@@ -47,6 +60,10 @@ describe("Desktop MCP and Skills settings", () => {
 				customizeSource.includes('id: "rules"'),
 			listsRules: ruleSource.includes("window.devo.rules.list"),
 			createsRules: ruleSource.includes("window.devo.rules.create"),
+			opensMcpConfigIpc:
+				ipcSource.includes("mcp:open-config") &&
+				preloadSource.includes("mcp:open-config") &&
+				ipcSource.includes("MCP_CONFIG_OPEN_PATH"),
 			popsFileSubmenu: menuSource.includes("explicitSubmenu") && menuSource.includes("activePopupMenu"),
 		}).toEqual({
 			sidebarEntry: true,
@@ -54,6 +71,7 @@ describe("Desktop MCP and Skills settings", () => {
 			customizeTabs: true,
 			listsRules: true,
 			createsRules: true,
+			opensMcpConfigIpc: true,
 			popsFileSubmenu: true,
 		})
 	})

--- a/apps/desktop/src/renderer/components/settings/notification-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/notification-settings.tsx
@@ -8,6 +8,7 @@ import {
 import { Switch } from "@devo/ui/components/switch"
 import { useCallback } from "react"
 import { useSettings } from "../../hooks/use-settings"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -26,10 +27,8 @@ export function NotificationSettings() {
 		typeof window !== "undefined" && "devo" in window && window.devo.platform === "darwin"
 
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Notifications</h2>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader title="Notifications" />
 
 			<SettingsSection>
 				<SettingsRow

--- a/apps/desktop/src/renderer/components/settings/provider-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/provider-settings.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from "react"
 import { useProviderVendors } from "../../hooks/use-devo-data"
 import { ProviderIcon } from "./provider-icon"
 import { ProviderVendorDialog } from "./provider-vendor-dialog"
+import { SettingsHeader } from "./settings-header"
 import { SettingsSection } from "./settings-section"
 
 interface ProviderSettingsViewProps {
@@ -68,9 +69,9 @@ export function ProviderSettingsView({
 
 	if (error) {
 		return (
-			<div className="flex flex-col gap-8">
+			<div className="flex flex-col gap-10">
 				<ProviderSettingsHeader onAddProvider={openAddDialog} />
-				<div className="flex items-center gap-3 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+				<div className="flex items-center gap-3 rounded-[18px] border border-destructive/40 bg-destructive/10 px-5 py-3.5 text-[15px] text-destructive">
 					<AlertCircleIcon className="size-4 shrink-0" aria-hidden="true" />
 					<span>Failed to load providers: {error}</span>
 					<Button variant="outline" size="sm" className="ml-auto" onClick={onReload}>
@@ -83,22 +84,24 @@ export function ProviderSettingsView({
 	}
 
 	return (
-		<div className="flex flex-col gap-8">
+		<div className="flex flex-col gap-10">
 			<ProviderSettingsHeader onAddProvider={openAddDialog} />
 
 			{providerVendors.length === 0 ? (
-				<Empty className="border">
+				<Empty className="rounded-[18px] border border-border/60 bg-background shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
 					<EmptyHeader>
 						<EmptyMedia variant="icon">
 							<PlugZapIcon aria-hidden="true" />
 						</EmptyMedia>
-						<EmptyTitle>No providers configured</EmptyTitle>
-						<EmptyDescription>
+						<EmptyTitle className="text-[22px] font-normal tracking-[-0.03em]">
+							No providers configured
+						</EmptyTitle>
+						<EmptyDescription className="text-[15px] leading-6">
 							Add a provider endpoint and model binding to make it available in Desktop.
 						</EmptyDescription>
 					</EmptyHeader>
 					<EmptyContent>
-						<Button onClick={openAddDialog}>
+						<Button className="h-9 rounded-full px-4" onClick={openAddDialog}>
 							<PlusIcon data-icon="inline-start" />
 							Add Provider
 						</Button>
@@ -130,26 +133,28 @@ export function ProviderSettingsView({
 
 function ProviderSettingsHeader({ onAddProvider }: { onAddProvider: () => void }) {
 	return (
-		<div className="flex items-start justify-between gap-4">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Providers</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
+		<SettingsHeader
+			title="Providers"
+			action={
+				<Button variant="secondary" className="h-9 rounded-full px-4" onClick={onAddProvider}>
+					<PlusIcon data-icon="inline-start" />
+					Add Provider
+				</Button>
+			}
+			description={
+				<>
 					Connect AI providers to use their models.{" "}
 					<a
 						href="https://devo.ai/docs/providers/"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="text-primary hover:underline"
+						className="text-foreground/80 underline-offset-4 hover:underline"
 					>
 						Learn more &rsaquo;
 					</a>
-				</p>
-			</div>
-			<Button onClick={onAddProvider}>
-				<PlusIcon data-icon="inline-start" />
-				Add Provider
-			</Button>
-		</div>
+				</>
+			}
+		/>
 	)
 }
 
@@ -164,21 +169,21 @@ function ProviderVendorRow({
 	const endpoint = providerVendor.base_url ?? "Provider default endpoint"
 
 	return (
-		<div className="flex items-center gap-3 px-4 py-3">
+		<div className="flex items-center gap-3 px-5 py-3.5">
 			<ProviderIcon id={providerVendor.name} name={providerVendor.name} />
 			<div className="min-w-0 flex-1">
 				<div className="flex flex-wrap items-center gap-2">
-					<span className="text-sm font-medium">{providerVendor.name}</span>
+					<span className="text-[15px] font-normal tracking-[-0.01em]">{providerVendor.name}</span>
 					<Badge variant={providerVendor.enabled ? "secondary" : "outline"}>
 						{providerVendor.enabled ? "Enabled" : "Disabled"}
 					</Badge>
 				</div>
-				<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+				<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
 					<span>{endpoint}</span>
 					<span>{wireApis}</span>
 				</div>
 			</div>
-			<Button variant="outline" size="sm" onClick={onEdit}>
+			<Button variant="outline" size="sm" className="rounded-full" onClick={onEdit}>
 				<PencilIcon data-icon="inline-start" />
 				Edit
 			</Button>
@@ -188,11 +193,11 @@ function ProviderVendorRow({
 
 function ProviderSettingsLoading() {
 	return (
-		<div className="flex flex-col gap-8">
+		<div className="flex flex-col gap-10">
 			<ProviderSettingsHeader onAddProvider={() => {}} />
 			<SettingsSection title="Configured Providers">
 				{[0, 1, 2].map((index) => (
-					<div key={index} className="flex items-center gap-3 px-4 py-3">
+					<div key={index} className="flex items-center gap-3 px-5 py-3.5">
 						<Skeleton className="size-8 rounded-full" />
 						<div className="flex flex-1 flex-col gap-2">
 							<Skeleton className="h-4 w-32" />

--- a/apps/desktop/src/renderer/components/settings/rule-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/rule-settings.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner"
 import type { RuleFileInfo } from "../../../preload/api"
 import { desktopFoldersAtom } from "../../atoms/desktop-folders"
 import { discoveryAtom } from "../../atoms/discovery"
+import { SettingsHeader } from "../settings/settings-header"
 import { SettingsRow } from "../settings/settings-row"
 import { SettingsSection } from "../settings/settings-section"
 
@@ -87,17 +88,21 @@ export function RuleSettings({
 	})
 
 	return (
-		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-8"}>
+		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-10"}>
 			{!embedded && (
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Rules</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Agent instructions live in <code className="rounded bg-muted px-1 py-0.5 text-xs">AGENTS.md</code>.
-					Devo also reads <code className="rounded bg-muted px-1 py-0.5 text-xs">AGENTS.override.md</code>,{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-xs">CLAUDE.md</code>, and{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-xs">PROMPT.md</code>.
-				</p>
-			</div>
+				<SettingsHeader
+					title="Rules"
+					description={
+						<>
+							Agent instructions live in{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">AGENTS.md</code>. Devo also
+							reads{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">AGENTS.override.md</code>,{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">CLAUDE.md</code>, and{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">PROMPT.md</code>.
+						</>
+					}
+				/>
 			)}
 
 			<SettingsSection title="Instruction files">

--- a/apps/desktop/src/renderer/components/settings/server-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/server-settings.tsx
@@ -18,6 +18,7 @@ import type { NativeTrafficLogState, NetworkProxyMode } from "../../../preload/a
 import { normalizeProxyUrl } from "../../../shared/network-proxy"
 import { serverConnectedAtom, serverUrlAtom } from "../../atoms/connection"
 import { useSettings } from "../../hooks/use-settings"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -65,13 +66,11 @@ export function ServerSettings({ initialNativeTrafficLogState = null }: ServerSe
 	}
 
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Server</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Devo Desktop manages a private local stdio Native process.
-				</p>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader
+				title="Server"
+				description="Devo Desktop manages a private local stdio Native process."
+			/>
 
 			<SettingsSection>
 				<SettingsRow
@@ -227,16 +226,16 @@ export function NativeTrafficLogStatus({
 				</Button>
 			</SettingsRow>
 			{expanded && (
-				<div className="space-y-2 px-4 py-3">
-					<div className="text-sm font-medium">Current log file</div>
+				<div className="space-y-2 px-5 py-3.5">
+					<div className="text-[15px] font-normal tracking-[-0.01em]">Current log file</div>
 					{state.path ? (
-						<code className="block truncate rounded bg-muted px-2 py-1.5 text-xs text-muted-foreground">
+						<code className="block truncate rounded-md bg-muted px-2 py-1.5 text-[13px] text-muted-foreground">
 							{state.path}
 						</code>
 					) : (
-						<p className="text-sm text-muted-foreground">No log file path is available.</p>
+						<p className="text-[13px] text-muted-foreground">No log file path is available.</p>
 					)}
-					<p className="text-xs text-muted-foreground">
+					<p className="text-[13px] leading-5 text-muted-foreground">
 						Traces are written under DEVO_HOME/traces/ (default ~/.devo/traces/). The log may
 						include prompts, paths, tool arguments, and provider details.
 					</p>

--- a/apps/desktop/src/renderer/components/settings/settings-header.tsx
+++ b/apps/desktop/src/renderer/components/settings/settings-header.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react"
+
+interface SettingsHeaderProps {
+	title: string
+	description?: ReactNode
+	action?: ReactNode
+}
+
+export function SettingsHeader({ title, description, action }: SettingsHeaderProps) {
+	return (
+		<div className="flex items-start justify-between gap-4">
+			<div className="min-w-0">
+				<h2 className="select-none text-[32px] font-normal leading-tight tracking-[-0.03em] text-foreground">
+					{title}
+				</h2>
+				{description ? (
+					<p className="mt-2 max-w-xl text-[15px] leading-6 text-muted-foreground">{description}</p>
+				) : null}
+			</div>
+			{action ? <div className="mt-1.5 shrink-0">{action}</div> : null}
+		</div>
+	)
+}

--- a/apps/desktop/src/renderer/components/settings/settings-page.tsx
+++ b/apps/desktop/src/renderer/components/settings/settings-page.tsx
@@ -1,9 +1,4 @@
-import {
-	SidebarContent,
-	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
-} from "@devo/ui/components/sidebar"
+import { SidebarContent } from "@devo/ui/components/sidebar"
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router"
 import { useAtomValue } from "jotai"
 import {
@@ -21,6 +16,7 @@ import { useEffect } from "react"
 import { lastAppRouteAtom } from "../../atoms/ui"
 import { resolveSettingsBackTarget } from "../../lib/app-navigation"
 import { useSetSidebarSlot } from "../sidebar-slot-context"
+import { TopActionRow, sidebarPrimaryIconClass } from "../sidebar/sidebar-top-action"
 
 // ============================================================
 // Tab definitions
@@ -67,7 +63,7 @@ export function SettingsPage() {
 
 	return (
 		<div className="h-full overflow-y-auto">
-			<div className="mx-auto max-w-2xl px-10 py-10">
+			<div className="mx-auto max-w-3xl px-10 py-14 sm:px-12">
 				<Outlet />
 			</div>
 		</div>
@@ -88,36 +84,26 @@ function SettingsSidebarContent() {
 
 	return (
 		<SidebarContent className="gap-0 bg-transparent px-0 pb-3">
-			<div className="flex shrink-0 flex-col gap-1 px-3 pb-7">
-				<button
-					type="button"
+			<div className="flex min-h-0 flex-1 flex-col gap-1 overflow-auto px-3 pb-7">
+				<TopActionRow
+					icon={<ArrowLeftIcon aria-hidden="true" className={sidebarPrimaryIconClass} />}
 					onClick={() => navigate(resolveSettingsBackTarget(lastAppRoute))}
-					className="flex h-8 w-full items-center gap-2.5 rounded-lg px-1.5 text-left text-[13px] font-normal text-muted-foreground transition-colors hover:bg-black/[0.04] hover:text-sidebar-foreground dark:hover:bg-white/[0.06]"
 				>
-					<span className="flex size-[18px] shrink-0 items-center justify-center text-sidebar-foreground/90">
-						<ArrowLeftIcon aria-hidden="true" className="size-[18px]" />
-					</span>
-					<span className="min-w-0 flex-1 truncate">Back to app</span>
-				</button>
-			</div>
-			<div className="min-h-0 flex-1 overflow-auto px-3 pb-2">
-				<SidebarMenu>
-					{tabs.map((tab) => {
-						const Icon = tab.icon
-						return (
-							<SidebarMenuItem key={tab.id}>
-								<SidebarMenuButton
-									isActive={activeTab === tab.id}
-									onClick={() => navigate({ to: `/settings/${tab.id}` })}
-									tooltip={tab.label}
-								>
-									<Icon aria-hidden="true" className="size-4" />
-									<span>{tab.label}</span>
-								</SidebarMenuButton>
-							</SidebarMenuItem>
-						)
-					})}
-				</SidebarMenu>
+					Back to app
+				</TopActionRow>
+				{tabs.map((tab) => {
+					const Icon = tab.icon
+					return (
+						<TopActionRow
+							key={tab.id}
+							icon={<Icon aria-hidden="true" className={sidebarPrimaryIconClass} />}
+							onClick={() => navigate({ to: `/settings/${tab.id}` })}
+							isActive={activeTab === tab.id}
+						>
+							{tab.label}
+						</TopActionRow>
+					)
+				})}
 			</div>
 		</SidebarContent>
 	)

--- a/apps/desktop/src/renderer/components/settings/settings-row.tsx
+++ b/apps/desktop/src/renderer/components/settings/settings-row.tsx
@@ -13,9 +13,9 @@ export function SettingsRow({ label, description, htmlFor, children }: SettingsR
 	const controlId = htmlFor ?? autoId
 
 	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3">
+		<div className="flex items-center justify-between gap-4 px-5 py-3.5">
 			<div className="flex min-w-0 flex-col gap-0.5">
-				<label htmlFor={controlId} className="text-[13px] font-medium">
+				<label htmlFor={controlId} className="text-[15px] font-normal tracking-[-0.01em]">
 					{label}
 				</label>
 				{description && (

--- a/apps/desktop/src/renderer/components/settings/settings-section.tsx
+++ b/apps/desktop/src/renderer/components/settings/settings-section.tsx
@@ -3,23 +3,34 @@ import { type ReactNode, useId } from "react"
 interface SettingsSectionProps {
 	title?: string
 	description?: string
+	action?: ReactNode
 	children: ReactNode
 }
 
-export function SettingsSection({ title, description, children }: SettingsSectionProps) {
+export function SettingsSection({ title, description, action, children }: SettingsSectionProps) {
 	const sectionId = useId()
 
 	return (
 		<section className="space-y-3" aria-labelledby={title ? sectionId : undefined}>
 			{title && (
-				<div>
-					<h3 id={sectionId} className="text-[13px] font-medium tracking-wide text-muted-foreground">
-						{title}
-					</h3>
-					{description && <p className="mt-1 text-[13px] leading-5 text-muted-foreground">{description}</p>}
+				<div className="flex items-start justify-between gap-3 px-1">
+					<div>
+						<h3
+							id={sectionId}
+							className="text-[15px] font-normal tracking-[-0.02em] text-muted-foreground"
+						>
+							{title}
+						</h3>
+						{description && (
+							<p className="mt-1 text-[13px] leading-5 text-muted-foreground/80">{description}</p>
+						)}
+					</div>
+					{action}
 				</div>
 			)}
-			<div className="divide-y divide-border/70 overflow-hidden rounded-xl border border-border/70">{children}</div>
+			<div className="divide-y divide-border/50 overflow-hidden rounded-[18px] border border-border/60 bg-background shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
+				{children}
+			</div>
 		</section>
 	)
 }

--- a/apps/desktop/src/renderer/components/settings/setup-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/setup-settings.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useEffect, useState } from "react"
 import type { DevoCheckResult } from "../../../preload/api"
 import { onboardingStateAtom } from "../../atoms/onboarding"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -33,10 +34,8 @@ const PROVIDER_LABELS: Record<string, string> = {
 
 export function SetupSettings() {
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Setup</h2>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader title="Setup" />
 
 			<DevoStatusSection />
 			<MigrationSection />
@@ -106,7 +105,7 @@ function DevoStatusSection() {
 			</SettingsRow>
 
 			{result && !result.compatible && result.message && (
-				<div className="px-4 py-2 text-xs text-amber-500">{result.message}</div>
+				<div className="px-5 py-2.5 text-[13px] text-amber-500">{result.message}</div>
 			)}
 		</SettingsSection>
 	)

--- a/apps/desktop/src/renderer/components/settings/skill-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/skill-settings.tsx
@@ -11,6 +11,7 @@ import { BookOpenIcon, RefreshCwIcon } from "lucide-react"
 import { serverConnectedAtom } from "../../atoms/connection"
 import { discoveryAtom } from "../../atoms/discovery"
 import { getBaseClient, getProjectClient } from "../../services/connection-manager"
+import { SettingsHeader } from "./settings-header"
 import { SettingsRow } from "./settings-row"
 import { SettingsSection } from "./settings-section"
 
@@ -91,17 +92,19 @@ export function SkillSettings({
 	})
 
 	return (
-		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-8"}>
+		<div className={embedded ? "space-y-6 px-8 py-8" : "space-y-10"}>
 			{!embedded && (
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Skills</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Skills are discovered from user, workspace, plugin, and system roots. Disable a skill to
-					keep it off this machine. Insert one in chat with{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-xs">/skills</code> or{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-xs">@</code>.
-				</p>
-			</div>
+				<SettingsHeader
+					title="Skills"
+					description={
+						<>
+							Skills are discovered from user, workspace, plugin, and system roots. Disable a skill to
+							keep it off this machine. Insert one in chat with{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">/skills</code> or{" "}
+							<code className="rounded bg-muted px-1 py-0.5 text-[13px]">@</code>.
+						</>
+					}
+				/>
 			)}
 
 			<SettingsSection title="Installed skills">

--- a/apps/desktop/src/renderer/components/settings/worktree-settings.tsx
+++ b/apps/desktop/src/renderer/components/settings/worktree-settings.tsx
@@ -16,6 +16,7 @@ import { GitForkIcon, Loader2Icon, RotateCcwIcon, TrashIcon } from "lucide-react
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useProjectList } from "../../hooks/use-agents"
 import { listWorktrees, removeWorktree, resetWorktree } from "../../services/worktree-service"
+import { SettingsHeader } from "./settings-header"
 import { SettingsSection } from "./settings-section"
 
 // ============================================================
@@ -134,19 +135,17 @@ export function WorktreeSettings() {
 	const projectCount = projects.length
 
 	return (
-		<div className="space-y-8">
-			<div>
-				<h2 className="text-[22px] font-medium tracking-tight">Worktrees</h2>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Manage git worktrees created for isolated agent sessions.
-				</p>
-			</div>
+		<div className="space-y-10">
+			<SettingsHeader
+				title="Worktrees"
+				description="Manage git worktrees created for isolated agent sessions."
+			/>
 
 			{/* Summary */}
 			<SettingsSection title="Overview">
-				<div className="flex items-center gap-2 px-4 py-3">
+				<div className="flex items-center gap-2 px-5 py-3.5">
 					<GitForkIcon className="size-4 text-muted-foreground" aria-hidden="true" />
-					<span className="text-sm">
+					<span className="text-[15px] font-normal tracking-[-0.01em]">
 						{worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""}
 						{projectCount > 0 && (
 							<span className="text-muted-foreground">
@@ -164,10 +163,10 @@ export function WorktreeSettings() {
 					<Loader2Icon className="size-5 animate-spin text-muted-foreground" />
 				</div>
 			) : worktrees.length === 0 ? (
-				<div className="rounded-lg border border-dashed border-border py-8 text-center">
+				<div className="rounded-[18px] border border-dashed border-border/60 py-10 text-center">
 					<GitForkIcon className="mx-auto size-8 text-muted-foreground/30" aria-hidden="true" />
-					<p className="mt-2 text-sm text-muted-foreground">No worktrees</p>
-					<p className="text-xs text-muted-foreground/60">
+					<p className="mt-3 text-[15px] font-normal tracking-[-0.01em] text-muted-foreground">No worktrees</p>
+					<p className="mt-1 text-[13px] text-muted-foreground/60">
 						Worktrees will appear here when you create sessions in worktree mode.
 					</p>
 				</div>
@@ -207,14 +206,16 @@ function WorktreeRow({
 	onReset: () => void
 }) {
 	return (
-		<div className="flex items-center gap-3 px-4 py-3">
+		<div className="flex items-center gap-3 px-5 py-3.5">
 			<GitForkIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
 
 			<div className="min-w-0 flex-1">
 				<div className="flex items-center gap-2">
-					<span className="truncate text-sm font-medium">{dirName(worktree.directory)}</span>
+					<span className="truncate text-[15px] font-normal tracking-[-0.01em]">
+						{dirName(worktree.directory)}
+					</span>
 				</div>
-				<div className="flex items-center gap-2 text-xs text-muted-foreground/60">
+				<div className="flex items-center gap-2 text-[13px] text-muted-foreground/60">
 					<span>{worktree.projectName}</span>
 					<span>-</span>
 					<span className="truncate">{worktree.directory}</span>

--- a/apps/desktop/src/renderer/components/sidebar-layout.tsx
+++ b/apps/desktop/src/renderer/components/sidebar-layout.tsx
@@ -40,6 +40,7 @@ import { isSettingsRoute } from "../lib/app-navigation"
 import type { Agent, SidebarProject } from "../lib/types"
 import { createDesktopFolder, pickDirectory, statDesktopFolders } from "../services/backend"
 import {
+	deleteProjectSessions,
 	loadProjectSessions,
 	refillProjectSessionsAfterDelete,
 } from "../services/connection-manager"
@@ -520,6 +521,7 @@ export function SidebarLayout() {
 
 	const handleRemoveFolder = useCallback(
 		async (project: SidebarProject) => {
+			await deleteProjectSessions(project.directory)
 			const nextFolders = removeDesktopFolder(desktopFolders, project.directory)
 			await persistDesktopFolders(nextFolders)
 			setFolderStatuses((previous) => {

--- a/apps/desktop/src/renderer/components/sidebar/app-sidebar-content.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/app-sidebar-content.tsx
@@ -11,7 +11,7 @@ import {
 	SettingsIcon,
 	SlidersHorizontalIcon,
 } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { activeServerConfigAtom } from "../../atoms/connection"
 import { sandboxMappingsAtom } from "../../atoms/derived/agents"
 import { automationsEnabledAtom } from "../../atoms/feature-flags"
@@ -36,6 +36,7 @@ import {
 import { AddProjectMenu, SidebarMainMenu } from "./sidebar-menus"
 import { sidebarPreferencesAtom } from "./sidebar-preferences"
 import { ProjectRow, SessionRow } from "./sidebar-rows"
+import { TopActionRow, sidebarPrimaryIconClass } from "./sidebar-top-action"
 
 interface AppSidebarContentProps {
 	agents: Agent[]
@@ -47,38 +48,6 @@ interface AppSidebarContentProps {
 	onRenameSession?: (agent: Agent, title: string) => Promise<void>
 	onDeleteSession?: (agent: Agent) => Promise<void>
 	onForkSession?: (agent: Agent) => Promise<void>
-}
-
-const sidebarPrimaryIconClass = "size-[15px] stroke-[1.5]"
-
-function TopActionRow({
-	children,
-	icon,
-	onClick,
-	isActive,
-}: {
-	children: ReactNode
-	icon: ReactNode
-	onClick: () => void
-	isActive?: boolean
-}) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			className={cn(
-				"flex h-8 w-full items-center gap-2.5 rounded-lg px-1.5 text-left text-[13px] font-normal transition-colors",
-				isActive
-					? "bg-black/[0.06] text-sidebar-foreground dark:bg-white/[0.08]"
-					: "text-sidebar-foreground hover:bg-black/[0.04] dark:hover:bg-white/[0.06]",
-			)}
-		>
-			<span className="flex size-4 shrink-0 items-center justify-center text-sidebar-foreground/90">
-				{icon}
-			</span>
-			<span className="min-w-0 flex-1 truncate">{children}</span>
-		</button>
-	)
 }
 
 function ProjectSection({

--- a/apps/desktop/src/renderer/components/sidebar/sidebar-folder-dialogs.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/sidebar-folder-dialogs.test.tsx
@@ -17,7 +17,7 @@ const project: SidebarProject = {
 }
 
 describe("sidebar folder dialogs", () => {
-	test("explains remove only affects Devo Desktop and not disk", () => {
+	test("explains remove deletes all sessions in the folder, not the disk folder", () => {
 		const markup = renderToStaticMarkup(
 			<FolderRemoveDialogBody
 				project={project}
@@ -30,12 +30,14 @@ describe("sidebar folder dialogs", () => {
 
 		expect({
 			title: markup.includes("Remove folder from Devo Desktop"),
-			desktopOnly: markup.includes("only removes it from the Desktop sidebar"),
-			notDisk: markup.includes("does not delete anything from disk"),
+			deletesSessions: markup.includes("permanently deletes all sessions in this folder"),
+			cannotUndo: markup.includes("cannot be undone"),
+			keepsDiskFolder: markup.includes("The folder on disk will not be deleted"),
 		}).toEqual({
 			title: true,
-			desktopOnly: true,
-			notDisk: true,
+			deletesSessions: true,
+			cannotUndo: true,
+			keepsDiskFolder: true,
 		})
 	})
 
@@ -53,9 +55,11 @@ describe("sidebar folder dialogs", () => {
 		expect({
 			title: markup.includes("Folder no longer exists"),
 			removeQuestion: markup.includes("Remove it from Devo Desktop"),
+			deletesSessions: markup.includes("permanently deletes all sessions in this folder"),
 		}).toEqual({
 			title: true,
 			removeQuestion: true,
+			deletesSessions: true,
 		})
 	})
 })

--- a/apps/desktop/src/renderer/components/sidebar/sidebar-folder-dialogs.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/sidebar-folder-dialogs.tsx
@@ -57,8 +57,8 @@ export function FolderRemoveDialogBody({
 				<p className="text-sm text-muted-foreground">
 					Remove{" "}
 					<span className="font-medium text-foreground">{project?.name || "this folder"}</span>{" "}
-					from Devo Desktop? This only removes it from the Desktop sidebar and does not
-					delete anything from disk.
+					from Devo Desktop? This permanently deletes all sessions in this folder and cannot
+					be undone. The folder on disk will not be deleted.
 				</p>
 			</div>
 			{error && (
@@ -135,7 +135,8 @@ export function MissingFolderDialogBody({
 				</h2>
 				<p className="text-sm text-muted-foreground">
 					<span className="font-medium text-foreground">{project?.name || "This folder"}</span>{" "}
-					cannot be found on disk. Remove it from Devo Desktop?
+					cannot be found on disk. Remove it from Devo Desktop? This permanently deletes all
+					sessions in this folder and cannot be undone.
 				</p>
 			</div>
 			{error && (

--- a/apps/desktop/src/renderer/components/sidebar/sidebar-top-action.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/sidebar-top-action.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { TopActionRow, sidebarPrimaryIconClass } from "./sidebar-top-action"
+
+describe("TopActionRow", () => {
+	test("keeps the New chat / Search action treatment", () => {
+		const markup = renderToStaticMarkup(
+			<TopActionRow
+				icon={<span className={sidebarPrimaryIconClass} />}
+				onClick={() => {}}
+				isActive
+			>
+				New chat
+			</TopActionRow>,
+		)
+
+		expect({
+			hasHeight: markup.includes("h-8"),
+			hasTextSize: markup.includes("text-[13px]"),
+			hasFontNormal: markup.includes("font-normal"),
+			hasRounded: markup.includes("rounded-lg"),
+			hasActiveBackground: markup.includes("bg-black/[0.06]"),
+			hasIconClass: markup.includes("size-[15px] stroke-[1.5]"),
+		}).toEqual({
+			hasHeight: true,
+			hasTextSize: true,
+			hasFontNormal: true,
+			hasRounded: true,
+			hasActiveBackground: true,
+			hasIconClass: true,
+		})
+	})
+})

--- a/apps/desktop/src/renderer/components/sidebar/sidebar-top-action.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/sidebar-top-action.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@devo/ui/lib/utils"
+import type { ReactNode } from "react"
+
+export const sidebarPrimaryIconClass = "size-[15px] stroke-[1.5]"
+
+export function TopActionRow({
+	children,
+	icon,
+	onClick,
+	isActive,
+}: {
+	children: ReactNode
+	icon: ReactNode
+	onClick: () => void
+	isActive?: boolean
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"flex h-8 w-full items-center gap-2.5 rounded-lg px-1.5 text-left text-[13px] font-normal transition-colors",
+				isActive
+					? "bg-black/[0.06] text-sidebar-foreground dark:bg-white/[0.08]"
+					: "text-sidebar-foreground hover:bg-black/[0.04] dark:hover:bg-white/[0.06]",
+			)}
+		>
+			<span className="flex size-4 shrink-0 items-center justify-center text-sidebar-foreground/90">
+				{icon}
+			</span>
+			<span className="min-w-0 flex-1 truncate">{children}</span>
+		</button>
+	)
+}

--- a/apps/desktop/src/renderer/services/backend-mcp-config.test.ts
+++ b/apps/desktop/src/renderer/services/backend-mcp-config.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { MCP_CONFIG_OPEN_PATH } from "../../shared/mcp-config"
+
+type OpenInCall = { directory: string; targetId: string }
+
+const openCalls: OpenInCall[] = []
+const originalWindow = globalThis.window
+
+const fakeDevo = {
+	mcp: undefined as { openConfig: () => Promise<{ path: string }> } | undefined,
+	openIn: {
+		openMcpConfig: undefined as (() => Promise<{ path: string }>) | undefined,
+		getTargets: async () => ({
+			targets: [],
+			availableTargets: ["cursor"],
+			preferredTarget: "cursor",
+		}),
+		open: async (directory: string, targetId: string) => {
+			openCalls.push({ directory, targetId })
+		},
+		setPreferred: async () => ({ success: true }),
+	},
+}
+
+Object.defineProperty(globalThis, "window", {
+	configurable: true,
+	value: { devo: fakeDevo },
+})
+
+const { openMcpConfigFile } = await import("./backend")
+
+describe("openMcpConfigFile", () => {
+	test("uses the existing openIn bridge when mcp.openConfig is missing", async () => {
+		openCalls.length = 0
+		fakeDevo.mcp = undefined
+		fakeDevo.openIn.openMcpConfig = undefined
+		await openMcpConfigFile()
+		expect(openCalls).toEqual([{ directory: MCP_CONFIG_OPEN_PATH, targetId: "cursor" }])
+	})
+
+	test("prefers mcp.openConfig when the preload method exists", async () => {
+		openCalls.length = 0
+		fakeDevo.mcp = {
+			openConfig: async () => ({ path: "/home/me/.devo/config.toml" }),
+		}
+		expect(await openMcpConfigFile()).toEqual({ path: "/home/me/.devo/config.toml" })
+		expect(openCalls).toEqual([])
+	})
+})
+
+afterAll(() => {
+	if (originalWindow === undefined) {
+		Reflect.deleteProperty(globalThis, "window")
+	} else {
+		Object.defineProperty(globalThis, "window", {
+			configurable: true,
+			value: originalWindow,
+		})
+	}
+})

--- a/apps/desktop/src/renderer/services/backend.ts
+++ b/apps/desktop/src/renderer/services/backend.ts
@@ -28,6 +28,7 @@ import type {
 	OpenInTargetsResult,
 	UpdateAutomationInput,
 } from "../../preload/api"
+import { MCP_CONFIG_OPEN_PATH } from "../../shared/mcp-config"
 import { createLogger } from "../lib/logger"
 
 const log = createLogger("backend")
@@ -361,6 +362,33 @@ export async function setOpenInPreferred(targetId: string): Promise<{ success: b
 		return window.devo.openIn.setPreferred(targetId)
 	}
 	throw new Error("Open-in targets are only available in Electron mode")
+}
+
+/**
+ * Ensures the user MCP config file exists and opens it with the General
+ * settings "Default open destination" app.
+ *
+ * Prefers dedicated preload methods when present. Falls back to the existing
+ * `openIn.open` bridge so this still works if the window was created before
+ * a newer `mcp` preload namespace was added.
+ */
+export async function openMcpConfigFile(): Promise<{ path?: string }> {
+	if (typeof window === "undefined" || !("devo" in window)) {
+		throw new Error("MCP config can only be edited in the desktop app")
+	}
+	if (typeof window.devo.mcp?.openConfig === "function") {
+		return window.devo.mcp.openConfig()
+	}
+	if (typeof window.devo.openIn.openMcpConfig === "function") {
+		return window.devo.openIn.openMcpConfig()
+	}
+	const { preferredTarget, availableTargets } = await window.devo.openIn.getTargets()
+	const targetId = preferredTarget ?? availableTargets[0]
+	if (!targetId) {
+		throw new Error("No app is available to open the MCP config file")
+	}
+	await window.devo.openIn.open(MCP_CONFIG_OPEN_PATH, targetId)
+	return {}
 }
 
 // ============================================================

--- a/apps/desktop/src/renderer/services/connection-manager.test.ts
+++ b/apps/desktop/src/renderer/services/connection-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import type { DevoClient } from "@devo-ai/sdk/v2/client"
 import type { Event, Session } from "../lib/types"
+import { discoveryAtom } from "../atoms/discovery"
 import { partsFamily, partStorageKey } from "../atoms/parts"
 import { projectPaginationFamily, sessionFamily, upsertSessionAtom } from "../atoms/sessions"
 import { appStore } from "../atoms/store"
@@ -47,6 +48,7 @@ class FakeEventStream {
 const streams = new Map<string, FakeEventStream>()
 let activeManager: typeof import("./connection-manager") | null = null
 let listSessionsImpl: (client: DevoClient, options?: unknown) => Promise<Session[]> = async () => []
+let deleteSessionImpl: (client: DevoClient, sessionId: string) => Promise<void> = async () => {}
 let getSessionStatusesImpl: () => Promise<Record<string, { type: string }>> = async () => ({})
 
 function streamFor(directory: string): FakeEventStream {
@@ -67,6 +69,7 @@ mock.module("./devo", () => ({
 	listProjects: async () => [],
 	projectsFromSessions: (sessions: Session[]) => sessions,
 	listSessions: async (client: DevoClient, options?: unknown) => listSessionsImpl(client, options),
+	deleteSession: async (client: DevoClient, sessionId: string) => deleteSessionImpl(client, sessionId),
 	subscribeToGlobalEvents: async (client: DevoClient) =>
 		streamFor(((client as unknown as { directory?: string }).directory) ?? "__base__"),
 }))
@@ -75,6 +78,7 @@ describe("connection manager project event bridge", () => {
 	beforeEach(() => {
 		streams.clear()
 		listSessionsImpl = async () => []
+		deleteSessionImpl = async () => {}
 		getSessionStatusesImpl = async () => ({})
 		;(globalThis as unknown as { window: Record<string, unknown> }).window = {}
 		;(globalThis as unknown as { requestAnimationFrame: (callback: FrameRequestCallback) => number }).requestAnimationFrame =
@@ -263,6 +267,105 @@ describe("connection manager project event bridge", () => {
 		}).toEqual({
 			otherProject: sessionB,
 			discoveryOnly: null,
+		})
+	})
+
+	test("deletes every listed session when a project folder is removed", async () => {
+		const directory = "/repo/remove-folder"
+		const otherDirectory = "/repo/keep-folder"
+		const sessions: Session[] = [
+			{
+				id: "keep-1",
+				directory: otherDirectory,
+				title: "Keep",
+				time: { created: 3, updated: 3 },
+			},
+			{
+				id: "remove-1",
+				directory,
+				title: "Remove 1",
+				time: { created: 2, updated: 2 },
+			},
+			{
+				id: "remove-2",
+				directory,
+				title: "Remove 2",
+				time: { created: 1, updated: 1 },
+			},
+		]
+		const deletedIds: string[] = []
+		let listOptions: unknown
+		const remainingIds = new Set(sessions.map((session) => session.id))
+		listSessionsImpl = async (client, options) => {
+			listOptions = options
+			const clientDirectory = (client as { directory?: string }).directory
+			return sessions.filter((session) => {
+				if (!remainingIds.has(session.id)) return false
+				if (clientDirectory === "__base__") return true
+				return session.directory === clientDirectory
+			})
+		}
+		deleteSessionImpl = async (_client, sessionId) => {
+			deletedIds.push(sessionId)
+			remainingIds.delete(sessionId)
+		}
+
+		const manager = await import(`./connection-manager?case=${Date.now()}`)
+		activeManager = manager
+		await manager.connectToDevo("devo://stdio")
+		await manager.loadAllProjects()
+		for (const session of sessions) {
+			appStore.set(upsertSessionAtom, { session, directory: session.directory ?? "" })
+		}
+		appStore.set(discoveryAtom, {
+			loaded: true,
+			loading: false,
+			error: null,
+			phase: "ready",
+			projects: [
+				{
+					id: "remove-project",
+					name: "remove-folder",
+					worktree: directory,
+					path: { root: directory },
+					time: { created: 1, updated: 1 },
+					sandboxes: [],
+				},
+				{
+					id: "keep-project",
+					name: "keep-folder",
+					worktree: otherDirectory,
+					path: { root: otherDirectory },
+					time: { created: 1, updated: 1 },
+					sandboxes: [],
+				},
+			],
+		})
+
+		await manager.deleteProjectSessions(directory)
+		await manager.loadProjectSessions(directory)
+
+		expect({
+			listOptions,
+			deletedIds,
+			removedFirst: appStore.get(sessionFamily("remove-1")),
+			removedSecond: appStore.get(sessionFamily("remove-2")),
+			kept: appStore.get(sessionFamily("keep-1"))?.session,
+			pagination: appStore.get(projectPaginationFamily(directory)),
+			discoveredWorktrees: appStore.get(discoveryAtom).projects.map((project) => project.worktree),
+		}).toEqual({
+			listOptions: { roots: true },
+			deletedIds: ["remove-1", "remove-2"],
+			removedFirst: null,
+			removedSecond: null,
+			kept: sessions[0],
+			pagination: {
+				loaded: false,
+				currentLimit: 5,
+				hasMore: true,
+				loading: false,
+			},
+			discoveredWorktrees: [otherDirectory],
 		})
 	})
 })

--- a/apps/desktop/src/renderer/services/connection-manager.ts
+++ b/apps/desktop/src/renderer/services/connection-manager.ts
@@ -1,11 +1,15 @@
 import type { DevoClient } from "@devo-ai/sdk/v2/client"
 import { processEvent } from "../atoms/actions/event-processor"
 import { authHeaderAtom, serverConnectedAtom, serverUrlAtom } from "../atoms/connection"
+import { discoveryAtom } from "../atoms/discovery"
 import { batchUpsertPartsAtom } from "../atoms/parts"
 import {
 	SESSIONS_PAGE_SIZE,
 	projectPaginationFamily,
 	removeSessionAtom,
+	resetProjectPaginationAtom,
+	sessionFamily,
+	sessionIdsAtom,
 	setProjectPaginationLoadingAtom,
 	setSessionsAtom,
 	updateProjectPaginationAtom,
@@ -24,6 +28,7 @@ import { directoriesMatch } from "../lib/directory-path"
 import type { Event, Session } from "../lib/types"
 import {
 	connectToServer,
+	deleteSession,
 	disposeAllInstances,
 	getSession,
 	getSessionStatuses,
@@ -402,6 +407,51 @@ export async function refillProjectSessionsAfterDelete(
 			error,
 		})
 	}
+}
+
+/**
+ * Permanently delete every listed session for a project directory.
+ * Used when removing a folder from Devo Desktop; the folder on disk is left untouched.
+ */
+export async function deleteProjectSessions(projectDirectory: string): Promise<void> {
+	const client = getProjectClient(projectDirectory)
+	if (!client) throw new Error("Not connected to Devo server")
+
+	const sessions = await listSessions(client, { roots: true })
+	log.info("Deleting all sessions for project", {
+		directory: projectDirectory,
+		count: sessions.length,
+	})
+
+	for (const session of sessions) {
+		await deleteSession(client, session.id)
+	}
+
+	if (discoveredSessions) {
+		const deletedIds = new Set(sessions.map((session) => session.id))
+		discoveredSessions = discoveredSessions.filter((session) => {
+			if (deletedIds.has(session.id)) return false
+			return !session.directory || !directoriesMatch(session.directory, projectDirectory)
+		})
+	}
+
+	for (const sessionId of [...appStore.get(sessionIdsAtom)]) {
+		const entry = appStore.get(sessionFamily(sessionId))
+		if (entry && directoriesMatch(entry.directory, projectDirectory)) {
+			appStore.set(removeSessionAtom, sessionId)
+		}
+	}
+
+	const discovery = appStore.get(discoveryAtom)
+	appStore.set(discoveryAtom, {
+		...discovery,
+		projects: discovery.projects.filter((project) => {
+			if (!project.worktree) return true
+			return !directoriesMatch(project.worktree, projectDirectory)
+		}),
+	})
+
+	appStore.set(resetProjectPaginationAtom, [projectDirectory])
 }
 
 /**

--- a/apps/desktop/src/shared/mcp-config.ts
+++ b/apps/desktop/src/shared/mcp-config.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared MCP config constants.
+ *
+ * Used by both the main process and the renderer. Keep this module
+ * free of Electron or React imports so it can be bundled in either context.
+ */
+
+/**
+ * Sentinel path for `open-in:open`. Main treats this as "open the user MCP
+ * config file" so the renderer can use the existing `window.devo.openIn`
+ * bridge when a newer `mcp.openConfig` preload method is not available yet.
+ */
+export const MCP_CONFIG_OPEN_PATH = "devo-mcp-config"

--- a/crates/server/src/runtime/connection.rs
+++ b/crates/server/src/runtime/connection.rs
@@ -1527,6 +1527,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mcp_tools_for_disabled_bundled_server_returns_empty() {
+        let temp = TempDir::new().expect("temp dir");
+        let runtime = build_runtime(temp.path());
+        let connection_id = initialized_connection(&runtime).await;
+        let response = runtime
+            .handle_incoming(
+                connection_id,
+                serde_json::json!({
+                    "id": 7,
+                    "method": "mcp/tools",
+                    "params": { "name": "code_search" }
+                }),
+            )
+            .await
+            .expect("mcp/tools response");
+        let result: SuccessResponse<devo_protocol::native::rpc_admin::McpToolsResult> =
+            serde_json::from_value(response).expect("deserialize mcp/tools");
+        assert_eq!(
+            result.result,
+            devo_protocol::native::rpc_admin::McpToolsResult { tools: Vec::new() }
+        );
+    }
+
+    #[tokio::test]
     async fn mcp_list_includes_bundled_disabled_code_search() {
         let temp = TempDir::new().expect("temp dir");
         let runtime = build_runtime(temp.path());

--- a/crates/server/src/runtime/mcp.rs
+++ b/crates/server/src/runtime/mcp.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use devo_core::McpServerId;
+use devo_core::McpServerStatus;
 use devo_core::McpStartupState;
 use devo_core::tools::ToolPlanConfig;
 use devo_core::tools::handlers;
@@ -74,22 +75,8 @@ impl ServerRuntime {
         let server_id = McpServerId(name.to_string());
         let manager = &self.deps.process_context.mcp_manager;
 
-        let needs_refresh = match manager.statuses().await {
-            Ok(statuses) => {
-                let status = statuses.iter().find(|status| status.server_id == server_id);
-                match status {
-                    None => true,
-                    Some(status) => {
-                        matches!(
-                            status.startup_state,
-                            McpStartupState::NotStarted
-                                | McpStartupState::Stopped
-                                | McpStartupState::Failed
-                        ) || status.tools.is_empty()
-                            && !matches!(status.startup_state, McpStartupState::Disabled)
-                    }
-                }
-            }
+        let statuses = match manager.statuses().await {
+            Ok(statuses) => statuses,
             Err(error) => {
                 return self.error_response(
                     request_id,
@@ -98,45 +85,55 @@ impl ServerRuntime {
                 );
             }
         };
+        let existing = statuses
+            .iter()
+            .find(|status| status.server_id == server_id)
+            .cloned();
 
-        if needs_refresh && let Err(error) = manager.refresh(&server_id).await {
-            // Still try to return whatever tools we have after a failed refresh.
-            tracing::warn!(server = %server_id, error = %error, "mcp/tools refresh failed");
-        }
-
-        match manager.statuses().await {
-            Ok(statuses) => {
-                let Some(status) = statuses
-                    .into_iter()
-                    .find(|status| status.server_id == server_id)
-                else {
+        let status = if mcp_tools_need_refresh(existing.as_ref()) {
+            match manager.refresh(&server_id).await {
+                Ok(status) => status,
+                Err(error) => {
+                    tracing::warn!(server = %server_id, error = %error, "mcp/tools refresh failed");
+                    match existing {
+                        Some(status) => status,
+                        None => {
+                            return self.error_response(
+                                request_id,
+                                ProtocolErrorCode::InvalidParams,
+                                format!("mcp server `{name}` not found"),
+                            );
+                        }
+                    }
+                }
+            }
+        } else {
+            match existing {
+                Some(status) => status,
+                None => {
                     return self.error_response(
                         request_id,
                         ProtocolErrorCode::InvalidParams,
                         format!("mcp server `{name}` not found"),
                     );
-                };
-                let mut tools = status
-                    .tools
-                    .into_iter()
-                    .map(|tool| McpToolEntry {
-                        name: tool.name,
-                        description: tool.description,
-                    })
-                    .collect::<Vec<_>>();
-                tools.sort_by(|left, right| left.name.cmp(&right.name));
-                serde_json::to_value(SuccessResponse {
-                    id: request_id,
-                    result: McpToolsResult { tools },
-                })
-                .expect("serialize mcp/tools response")
+                }
             }
-            Err(error) => self.error_response(
-                request_id,
-                ProtocolErrorCode::InternalError,
-                format!("failed to list mcp tools: {error}"),
-            ),
-        }
+        };
+
+        let mut tools = status
+            .tools
+            .into_iter()
+            .map(|tool| McpToolEntry {
+                name: tool.name,
+                description: tool.description,
+            })
+            .collect::<Vec<_>>();
+        tools.sort_by(|left, right| left.name.cmp(&right.name));
+        serde_json::to_value(SuccessResponse {
+            id: request_id,
+            result: McpToolsResult { tools },
+        })
+        .expect("serialize mcp/tools response")
     }
 
     pub(super) async fn handle_mcp_set_enabled(
@@ -316,5 +313,64 @@ fn startup_state_label(state: &McpStartupState) -> &'static str {
         McpStartupState::AuthRequired => "auth_required",
         McpStartupState::Degraded => "degraded",
         McpStartupState::Stopped => "stopped",
+    }
+}
+
+fn mcp_tools_need_refresh(status: Option<&McpServerStatus>) -> bool {
+    let Some(status) = status else {
+        return true;
+    };
+    match status.startup_state {
+        McpStartupState::Disabled => false,
+        McpStartupState::NotStarted | McpStartupState::Stopped | McpStartupState::Failed => true,
+        McpStartupState::Starting
+        | McpStartupState::Ready
+        | McpStartupState::AuthRequired
+        | McpStartupState::Degraded => status.tools.is_empty(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use devo_core::McpAuthState;
+    use devo_core::McpToolDescriptor;
+
+    fn status_with(startup_state: McpStartupState, tool_count: usize) -> McpServerStatus {
+        McpServerStatus {
+            server_id: McpServerId("docs".to_string()),
+            startup_state,
+            auth_state: McpAuthState::NotRequired,
+            tools: (0..tool_count)
+                .map(|index| McpToolDescriptor {
+                    server_id: McpServerId("docs".to_string()),
+                    name: format!("tool_{index}"),
+                    description: String::new(),
+                    input_schema: serde_json::json!({}),
+                })
+                .collect(),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            last_refreshed_at: None,
+        }
+    }
+
+    /// Trace: L2-DES-MCP-001
+    /// Verifies: mcp/tools does not start a disabled server and does start idle enabled ones.
+    #[test]
+    fn mcp_tools_refresh_skips_disabled_and_filled_ready_servers() {
+        assert_eq!(
+            [
+                mcp_tools_need_refresh(None),
+                mcp_tools_need_refresh(Some(&status_with(McpStartupState::Disabled, 0))),
+                mcp_tools_need_refresh(Some(&status_with(McpStartupState::NotStarted, 0))),
+                mcp_tools_need_refresh(Some(&status_with(McpStartupState::Ready, 0))),
+                mcp_tools_need_refresh(Some(&status_with(McpStartupState::Ready, 2))),
+                mcp_tools_need_refresh(Some(&status_with(McpStartupState::Failed, 0))),
+            ],
+            [true, false, true, true, false, true]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add an in-app Customize gallery plus MCP, Skills, and Rules settings, including plan-mode chat support from the earlier commit on this branch.
- Restyle Settings to match the new-chat homepage: large light titles, composer-like cards, and left-nav rows that use the same treatment as New chat / Search / Automations / Customize.
- Brand the Windows Electron taskbar icon in development, open `~/.devo/config.toml` from Customize, list MCP tools without starting disabled servers, and permanently delete a folder's sessions when it is removed from the sidebar.

## Test plan
- [ ] Open Customize from the sidebar and switch among Plugins, MCPs, Skills, and Rules.
- [ ] Open Settings and confirm titles, cards, and left nav match the home/sidebar chrome.
- [ ] On Windows, fully quit the client, run `bun run brand:electron-dev`, then `bun run dev` and confirm the taskbar icon is Devo rather than Electron.
- [ ] In Customize → MCPs, use Add and confirm `~/.devo/config.toml` opens in the preferred editor.
- [ ] In Settings → MCP, list servers, expand tools, and toggle enablement without launching disabled servers.
- [ ] Remove a folder from the sidebar and confirm its sessions are deleted while the directory on disk remains.

Made with [Cursor](https://cursor.com)