### PR TITLE
fix(tui): slash command polish and remove provider response timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ To bring your own key with a custom model manually:
 Full worked example (custom model parameters + API key) and protocol details:
 [Configuration](./docs/configuration.md#bring-your-own-api-key).
 
+## Slow Providers
+
+Provider responses are not subject to an application-level response timeout, so
+local models may take as long as necessary to load or generate output. Provider
+connections still have an internal connection-establishment deadline, and every
+request can be cancelled by the user.
+
 ## Docs
 
 - [Offline Installation](./docs/offline-installation.md)

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -214,6 +214,11 @@ devo resume <session-id>
 完整示例（自定义模型参数 + API key）与协议说明见
 [配置](./docs/configuration.zh-Hans.md#接入自有-api-key)。
 
+## 响应较慢的 Provider
+
+Provider 响应没有应用层总超时，因此本地模型可以按需要花费时间加载或生成输出。
+Provider 连接建立仍有内部期限，并且用户可以随时取消请求。
+
 ## Docs
 
 - [离线安装](./docs/offline-installation.zh-Hans.md)

--- a/apps/desktop/src/main/native-stdio-client.test.ts
+++ b/apps/desktop/src/main/native-stdio-client.test.ts
@@ -182,10 +182,12 @@ describe("StdioNativeClient", () => {
 			sessionList: requestTimeoutMsForMethod("session/list", 10_000),
 			mcpTools: requestTimeoutMsForMethod("mcp/tools", 10_000),
 			mcpSetEnabled: requestTimeoutMsForMethod("mcp/set_enabled", 5),
+			providerValidate: requestTimeoutMsForMethod("provider/validate", 10_000),
 		}).toEqual({
 			sessionList: 10_000,
 			mcpTools: 60_000,
 			mcpSetEnabled: 60_000,
+			providerValidate: undefined,
 		})
 	})
 

--- a/apps/desktop/src/main/native-stdio-client.ts
+++ b/apps/desktop/src/main/native-stdio-client.ts
@@ -29,14 +29,17 @@ export type JsonRpcId = number | string
 type PendingRequest = {
 	resolve: (value: unknown) => void
 	reject: (error: Error) => void
-	timer: ReturnType<typeof setTimeout>
+	timer?: ReturnType<typeof setTimeout>
 }
 
 const REQUEST_TIMEOUT_MS = 10_000
 /** MCP admin RPCs may start a lazy server before listing tools. */
 export const MCP_ADMIN_REQUEST_TIMEOUT_MS = 60_000
 
-export function requestTimeoutMsForMethod(method: string, fallbackMs: number): number {
+export function requestTimeoutMsForMethod(method: string, fallbackMs: number): number | undefined {
+	if (method === "provider/validate") {
+		return undefined
+	}
 	if (method === "mcp/tools" || method === "mcp/set_enabled") {
 		return Math.max(fallbackMs, MCP_ADMIN_REQUEST_TIMEOUT_MS)
 	}
@@ -295,11 +298,17 @@ export class StdioNativeClient implements NativeTransport {
 		const scopedParams = scopeRequestParams(method, params, directory)
 		const payload = { jsonrpc: "2.0", id, method, params: scopedParams }
 		const response = new Promise<unknown>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				if (!this.pending.delete(id)) return
-				this.pendingMethods.delete(id)
-				reject(new Error(`${method} request ${id} timed out`))
-			}, requestTimeoutMsForMethod(method, this.options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS))
+			const timeoutMs = requestTimeoutMsForMethod(
+				method,
+				this.options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+			)
+			const timer = timeoutMs === undefined
+				? undefined
+				: setTimeout(() => {
+						if (!this.pending.delete(id)) return
+						this.pendingMethods.delete(id)
+						reject(new Error(`${method} request ${id} timed out`))
+					}, timeoutMs)
 			this.pending.set(id, { resolve, reject, timer })
 		})
 		this.pendingMethods.set(id, method)
@@ -315,7 +324,7 @@ export class StdioNativeClient implements NativeTransport {
 		} catch (error) {
 			const reason = toError(error)
 			const pending = this.pending.get(id)
-			if (pending) clearTimeout(pending.timer)
+			if (pending?.timer !== undefined) clearTimeout(pending.timer)
 			this.pending.delete(id)
 			this.pendingMethods.delete(id)
 			this.close(reason)
@@ -399,7 +408,7 @@ export class StdioNativeClient implements NativeTransport {
 				const pending = this.pending.get(routed.id)
 				if (!pending) return
 				this.pending.delete(routed.id)
-				clearTimeout(pending.timer)
+				if (pending.timer !== undefined) clearTimeout(pending.timer)
 				const error = routed.message.error as { message?: string } | undefined
 				if (error) {
 					pending.reject(new Error(error.message ?? "Devo Native request failed"))
@@ -485,7 +494,7 @@ export class StdioNativeClient implements NativeTransport {
 			payload: { error: error.message },
 		})
 		for (const pending of this.pending.values()) {
-			clearTimeout(pending.timer)
+			if (pending.timer !== undefined) clearTimeout(pending.timer)
 			pending.reject(error)
 		}
 		this.pending.clear()

--- a/apps/desktop/src/renderer/components/settings/provider-settings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/provider-settings.test.tsx
@@ -196,6 +196,27 @@ describe("ProviderSettings", () => {
 		expect(calls).toEqual(["validate"])
 	})
 
+	test("cancelled validation does not upsert", async () => {
+		const calls: string[] = []
+		const params = buildProviderUpsertParams(formValues, null)
+		const client = {
+			provider: {
+				validate: async () => {
+					calls.push("validate")
+					return { data: { reply_preview: "OK" } }
+				},
+				upsert: async () => {
+					calls.push("upsert")
+					return { data: { provider_vendor: providerVendor } }
+				},
+			},
+		}
+
+		const cancelled = true
+		await saveProviderVendor(client, params, () => !cancelled)
+		expect(calls).toEqual([])
+	})
+
 	test("provider dialog scrolls form body while keeping footer actions outside", () => {
 		const queryClient = new QueryClient()
 		const markup = renderToStaticMarkup(

--- a/apps/desktop/src/renderer/components/settings/provider-vendor-dialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/provider-vendor-dialog.tsx
@@ -38,7 +38,7 @@ import { Spinner } from "@devo/ui/components/spinner"
 import { Textarea } from "@devo/ui/components/textarea"
 import { useQueryClient } from "@tanstack/react-query"
 import { SaveIcon } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { queryKeys } from "../../hooks/use-devo-data"
 import { createLogger } from "../../lib/logger"
 import { getBaseClient, invalidateConfigOptionCaches } from "../../services/connection-manager"
@@ -170,16 +170,19 @@ export function buildProviderUpsertParams(
 export async function saveProviderVendor(
 	client: ProviderVendorClient,
 	params: ProviderVendorUpsertParams,
+	shouldContinue: () => boolean = () => true,
 ) {
 	if (!params.model_binding) {
 		throw new Error("Model binding is required")
 	}
+	if (!shouldContinue()) return
 	const validateParams: ProviderValidateParams = {
 		provider_vendor: params.provider_vendor,
 		model_binding: params.model_binding,
 		...(params.api_key ? { api_key: params.api_key } : {}),
 	}
 	await client.provider.validate(validateParams)
+	if (!shouldContinue()) return
 	return client.provider.upsert(params)
 }
 
@@ -193,8 +196,10 @@ export function ProviderVendorDialog({
 	const [values, setValues] = useState<ProviderVendorFormValues>(() => initialValues(providerVendor))
 	const [error, setError] = useState<string | null>(null)
 	const [saving, setSaving] = useState(false)
+	const saveAttemptRef = useRef(0)
 
 	useEffect(() => {
+		saveAttemptRef.current += 1
 		if (!open) return
 		setValues(initialValues(providerVendor))
 		setError(null)
@@ -211,13 +216,15 @@ export function ProviderVendorDialog({
 	const handleSubmit = useCallback(
 		async (event: React.FormEvent<HTMLFormElement>) => {
 			event.preventDefault()
+			const saveAttempt = ++saveAttemptRef.current
 			setSaving(true)
 			setError(null)
 			try {
 				const client = getBaseClient()
 				if (!client) throw new Error("Not connected to server")
 				const params = buildProviderUpsertParams(values, providerVendor)
-				await saveProviderVendor(client, params)
+				await saveProviderVendor(client, params, () => saveAttemptRef.current === saveAttempt)
+				if (saveAttemptRef.current !== saveAttempt) return
 				invalidateConfigOptionCaches()
 				queryClient.invalidateQueries({ queryKey: queryKeys.providerVendors })
 				queryClient.invalidateQueries({
@@ -226,18 +233,32 @@ export function ProviderVendorDialog({
 				onSaved()
 				onOpenChange(false)
 			} catch (err) {
+				if (saveAttemptRef.current !== saveAttempt) return
 				const message = err instanceof Error ? err.message : "Failed to save provider"
 				log.error("Failed to save provider", { error: err })
 				setError(message)
 			} finally {
-				setSaving(false)
+				if (saveAttemptRef.current === saveAttempt) setSaving(false)
 			}
 		},
 		[values, providerVendor, queryClient, onSaved, onOpenChange],
 	)
 
+	const handleDialogOpenChange = useCallback(
+		(nextOpen: boolean) => {
+			if (!nextOpen) {
+				// Closing while validation is pending invalidates the continuation so
+				// a late validation response cannot persist the provider.
+				saveAttemptRef.current += 1
+				setSaving(false)
+			}
+			onOpenChange(nextOpen)
+		},
+		[onOpenChange],
+	)
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handleDialogOpenChange}>
 			<DialogContent className="flex max-h-[calc(100dvh-2rem)] overflow-hidden p-0 sm:max-w-xl">
 				<form onSubmit={handleSubmit} className="flex min-h-0 flex-col">
 					<DialogHeader className="px-6 pt-6 pb-4">
@@ -399,7 +420,7 @@ export function ProviderVendorDialog({
 						className="shrink-0 bg-background px-6 py-4"
 						data-testid="provider-dialog-footer"
 					>
-						<Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+						<Button type="button" variant="outline" onClick={() => handleDialogOpenChange(false)}>
 							Cancel
 						</Button>
 						<Button type="submit" disabled={saving}>

--- a/apps/web/content/docs/reference/config-reference.mdx
+++ b/apps/web/content/docs/reference/config-reference.mdx
@@ -125,6 +125,10 @@ Supported wire API values:
 - `openai_chat_completions`
 - `openai_responses`
 
+Provider responses do not have an application-level response timeout. Slow local
+models may take as long as needed to load or generate output; users can cancel a
+request at any time. Connection establishment retains an internal deadline.
+
 ## `[model_bindings.<id>]`
 
 | Field | Type | Meaning |

--- a/apps/web/content/docs/reference/config-reference.zh.mdx
+++ b/apps/web/content/docs/reference/config-reference.zh.mdx
@@ -123,6 +123,9 @@ Devo server methods。
 - `openai_chat_completions`
 - `openai_responses`
 
+Provider 响应没有应用层总超时。本地模型可以按需要花费时间加载或生成输出，
+用户可以随时取消请求；连接建立仍保留内部期限。
+
 ## `[model_bindings.<id>]`
 
 | Field | Type | Meaning |

--- a/crates/client/src/client_core.rs
+++ b/crates/client/src/client_core.rs
@@ -40,6 +40,12 @@ use crate::native_approval::resolve_approval_response;
 
 const SERVER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[derive(Clone, Copy)]
+enum ServerResponseWait {
+    Standard,
+    Unbounded,
+}
+
 /// Synthetic notifications emitted when falling back to detached `session/prompt`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ServerNotificationMessage {
@@ -362,6 +368,29 @@ impl ServerClientCore {
         P: Serialize,
         R: DeserializeOwned,
     {
+        self.request_with_wait(method, params, ServerResponseWait::Standard)
+            .await
+    }
+
+    async fn request_without_timeout<P, R>(&mut self, method: &str, params: P) -> Result<R>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        self.request_with_wait(method, params, ServerResponseWait::Unbounded)
+            .await
+    }
+
+    async fn request_with_wait<P, R>(
+        &mut self,
+        method: &str,
+        params: P,
+        wait: ServerResponseWait,
+    ) -> Result<R>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
         let request_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
         let (response_tx, response_rx) = oneshot::channel();
         // The transport reader resolves responses by this id (see
@@ -373,18 +402,32 @@ impl ServerClientCore {
             return Err(error);
         }
 
-        let response = match timeout(SERVER_RESPONSE_TIMEOUT, response_rx).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(error)) => {
-                self.pending.lock().await.remove(&request_id);
-                return Err(error)
-                    .with_context(|| format!("server dropped response for request {request_id}"));
+        let response = match wait {
+            ServerResponseWait::Standard => {
+                match timeout(SERVER_RESPONSE_TIMEOUT, response_rx).await {
+                    Ok(Ok(response)) => response,
+                    Ok(Err(error)) => {
+                        self.pending.lock().await.remove(&request_id);
+                        return Err(error).with_context(|| {
+                            format!("server dropped response for request {request_id}")
+                        });
+                    }
+                    Err(error) => {
+                        self.pending.lock().await.remove(&request_id);
+                        return Err(error)
+                            .with_context(|| format!("{method} request {request_id} timed out"));
+                    }
+                }
             }
-            Err(error) => {
-                self.pending.lock().await.remove(&request_id);
-                return Err(error)
-                    .with_context(|| format!("{method} request {request_id} timed out"));
-            }
+            ServerResponseWait::Unbounded => match response_rx.await {
+                Ok(response) => response,
+                Err(error) => {
+                    self.pending.lock().await.remove(&request_id);
+                    return Err(error).with_context(|| {
+                        format!("server dropped response for request {request_id}")
+                    });
+                }
+            },
         };
         if response.get("error").is_some() {
             bail_server_error(&response)?;
@@ -1021,7 +1064,8 @@ impl ServerClientCore {
         &mut self,
         params: devo_protocol::native::rpc_admin::ProviderValidateParams,
     ) -> Result<devo_protocol::native::rpc_admin::ProviderValidateResult> {
-        self.request("provider/validate", params).await
+        self.request_without_timeout("provider/validate", params)
+            .await
     }
 
     pub(crate) async fn command_exec(

--- a/crates/core/src/query/provider_retry.rs
+++ b/crates/core/src/query/provider_retry.rs
@@ -84,14 +84,6 @@ pub(crate) fn classify_error(e: &anyhow::Error) -> ErrorClass {
     }
 
     if e.chain().any(|cause| {
-        cause
-            .downcast_ref::<devo_provider::timeout::StreamIdleTimeoutError>()
-            .is_some()
-    }) {
-        return ErrorClass::NetworkError;
-    }
-
-    if e.chain().any(|cause| {
         cause.downcast_ref::<reqwest::Error>().is_some_and(|error| {
             error.is_timeout()
                 || error.is_connect()

--- a/crates/core/src/query/tests.rs
+++ b/crates/core/src/query/tests.rs
@@ -165,19 +165,6 @@ fn network_errors_are_retryable() {
             message: "provider request timed out".into(),
             provider_name: Some("test-provider".into()),
         }),
-        anyhow::Error::new(devo_provider::timeout::stream_idle_timeout_provider_error(
-            "openai",
-            "gpt-test",
-            devo_provider::timeout::StreamIdleTimeoutError {
-                idle_timeout: std::time::Duration::from_secs(60),
-            },
-        )),
-        anyhow::Error::new(devo_provider::timeout::StreamIdleTimeoutError {
-            idle_timeout: std::time::Duration::from_secs(60),
-        }),
-        anyhow::anyhow!(
-            "openai stream idle timeout for model gpt-test: provider stream idle timeout after 60s without receiving data"
-        ),
     ];
 
     for error in cases {

--- a/crates/provider/src/anthropic/messages.rs
+++ b/crates/provider/src/anthropic/messages.rs
@@ -21,6 +21,7 @@ use devo_protocol::StreamEvent;
 use devo_protocol::Usage;
 use devo_protocol::normalize_tool_result_messages;
 use futures::Stream;
+use futures::StreamExt;
 use reqwest::Client;
 use reqwest::header::ACCEPT_ENCODING;
 use reqwest::header::CACHE_CONTROL;
@@ -46,7 +47,6 @@ use crate::error::ProviderError;
 use crate::hosted_tools::append_anthropic_hosted_tools;
 use crate::http::invalid_status_error;
 use crate::merge_extra_body;
-use crate::timeout;
 
 /// <https://platform.claude.com/docs/en/api/messages>
 /// Anthropic provider backed by the official HTTP API.
@@ -387,16 +387,9 @@ impl ModelProviderSDK for AnthropicProvider {
 
             futures::pin_mut!(event_source);
             loop {
-                let event = match timeout::next_eventsource_event(&mut event_source).await {
-                    Ok(Some(event)) => event,
-                    Ok(None) => break,
-                    Err(idle) => {
-                        Err(timeout::stream_idle_timeout_provider_error(
-                            "anthropic",
-                            &request.model,
-                            idle,
-                        ))?
-                    }
+                let event = match event_source.next().await {
+                    Some(event) => event,
+                    None => break,
                 };
                 let event = match event {
                     Ok(event) => event,

--- a/crates/provider/src/http.rs
+++ b/crates/provider/src/http.rs
@@ -14,6 +14,7 @@ use std::sync::OnceLock;
 use tracing::warn;
 
 use crate::error::context_limit_error;
+use crate::timeout::connect_timeout;
 
 #[derive(Clone, Copy)]
 enum HttpClientKind {
@@ -100,23 +101,20 @@ impl ProviderHttpOptions {
         self.network_proxy.proxy_url.as_deref()
     }
 
-    /// HTTP client for non-streaming requests with total request timeout.
+    /// HTTP client for non-streaming requests with a connection timeout.
     pub(crate) fn build_request_client(&self) -> Result<Client> {
         cached_http_client(HttpClientKind::Request, &self.network_proxy, || {
-            let builder = Client::builder()
-                .connect_timeout(crate::timeout::connect_timeout())
-                .timeout(crate::timeout::request_timeout());
+            let builder = Client::builder().connect_timeout(connect_timeout());
             devo_network_proxy::apply_proxy_config(builder, &self.network_proxy)?
                 .build()
                 .context("failed to build provider HTTP client")
         })
     }
 
-    /// HTTP client for SSE streaming. Duration is bounded by per-chunk idle
-    /// timeout in the stream layer, not a single wall-clock request timeout.
+    /// HTTP client for SSE streaming with a connection timeout.
     pub(crate) fn build_streaming_client(&self) -> Result<Client> {
         cached_http_client(HttpClientKind::Streaming, &self.network_proxy, || {
-            let builder = Client::builder().connect_timeout(crate::timeout::connect_timeout());
+            let builder = Client::builder().connect_timeout(connect_timeout());
             devo_network_proxy::apply_proxy_config(builder, &self.network_proxy)?
                 .build()
                 .context("failed to build provider streaming HTTP client")

--- a/crates/provider/src/openai/chat_completions/stream.rs
+++ b/crates/provider/src/openai/chat_completions/stream.rs
@@ -8,6 +8,7 @@ use devo_protocol::{
     StreamEvent, Usage,
 };
 use futures::Stream;
+use futures::StreamExt;
 use reqwest_eventsource::{Event, EventSource};
 use serde::Deserialize;
 use serde_json::Value;
@@ -25,7 +26,6 @@ use crate::error::ProviderError;
 use crate::http::invalid_status_error;
 use crate::openai::error_payload::provider_error_from_payload;
 use crate::text_normalization::{TaggedTextFragment, TaggedTextParser};
-use crate::timeout;
 
 /// <https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events>
 /// Represents a streamed chunk of a chat completion response returned by the model, based on the provided input.
@@ -89,16 +89,9 @@ pub(super) async fn completion_stream(
 
         futures::pin_mut!(event_source);
         loop {
-            let event = match timeout::next_eventsource_event(&mut event_source).await {
-                Ok(Some(event)) => event,
-                Ok(None) => break,
-                Err(idle) => {
-                    Err(timeout::stream_idle_timeout_provider_error(
-                        "openai",
-                        &request.model,
-                        idle,
-                    ))?
-                }
+            let event = match event_source.next().await {
+                Some(event) => event,
+                None => break,
             };
             let event = match event {
                 Ok(event) => event,

--- a/crates/provider/src/openai/responses.rs
+++ b/crates/provider/src/openai/responses.rs
@@ -7,6 +7,7 @@ use devo_protocol::{
     StopReason, StreamEvent, Usage,
 };
 use futures::Stream;
+use futures::StreamExt;
 use reqwest::Client;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use reqwest_eventsource::{Event, EventSource};
@@ -17,7 +18,6 @@ use crate::error::ProviderError;
 use crate::hosted_tools::append_openai_responses_hosted_tools;
 use crate::http::invalid_status_error;
 use crate::text_normalization::{TaggedTextFragment, TaggedTextParser, split_tagged_text};
-use crate::timeout;
 use crate::{ModelProviderSDK, ProviderHttpOptions, merge_extra_body};
 
 use super::capabilities::{OpenAITransport, resolve_request_profile};
@@ -556,16 +556,9 @@ impl ModelProviderSDK for OpenAIResponsesProvider {
 
             futures::pin_mut!(event_source);
             loop {
-                let event = match timeout::next_eventsource_event(&mut event_source).await {
-                    Ok(Some(event)) => event,
-                    Ok(None) => break,
-                    Err(idle) => {
-                        Err(timeout::stream_idle_timeout_provider_error(
-                            "openai responses",
-                            &request.model,
-                            idle,
-                        ))?
-                    }
+                let event = match event_source.next().await {
+                    Some(event) => event,
+                    None => break,
                 };
                 let event = match event {
                     Ok(event) => event,

--- a/crates/provider/src/recovery_hint.rs
+++ b/crates/provider/src/recovery_hint.rs
@@ -4,7 +4,6 @@
 //! onboarding validation can show the same guidance.
 
 use crate::error::ProviderError;
-use crate::timeout::StreamIdleTimeoutError;
 
 /// Network / proxy / timeout guidance.
 pub const NETWORK_PROXY_HINT: &str = "Check network connectivity and proxy settings ([provider_http].proxy_url or HTTPS_PROXY/HTTP_PROXY).";
@@ -49,9 +48,6 @@ pub fn recovery_hint_for_anyhow(error: &anyhow::Error) -> Option<String> {
     for cause in error.chain() {
         if let Some(provider_error) = cause.downcast_ref::<ProviderError>() {
             return provider_error.recovery_hint().map(str::to_string);
-        }
-        if cause.downcast_ref::<StreamIdleTimeoutError>().is_some() {
-            return Some(NETWORK_PROXY_HINT.to_string());
         }
         if let Some(reqwest_error) = cause.downcast_ref::<reqwest::Error>() {
             if reqwest_error.status() == Some(reqwest::StatusCode::UNAUTHORIZED)
@@ -137,8 +133,6 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::timeout::StreamIdleTimeoutError;
-    use std::time::Duration;
 
     #[test]
     fn provider_timeout_maps_to_network_hint() {
@@ -179,20 +173,9 @@ mod tests {
     }
 
     #[test]
-    fn anyhow_idle_timeout_maps_to_network_hint() {
-        let error = anyhow::Error::new(StreamIdleTimeoutError {
-            idle_timeout: Duration::from_secs(60),
-        });
-        assert_eq!(
-            recovery_hint_for_anyhow(&error).as_deref(),
-            Some(NETWORK_PROXY_HINT)
-        );
-    }
-
-    #[test]
     fn message_heuristics_cover_validation_timeout() {
         assert_eq!(
-            recovery_hint_for_message("provider validation request timed out").as_deref(),
+            recovery_hint_for_message("provider connection timed out").as_deref(),
             Some(NETWORK_PROXY_HINT)
         );
         assert_eq!(

--- a/crates/provider/src/timeout.rs
+++ b/crates/provider/src/timeout.rs
@@ -1,83 +1,19 @@
-//! Provider HTTP and SSE stream timeout configuration.
+//! Provider HTTP connection timeout configuration.
 //!
-//! Non-streaming requests use a total [`request_timeout`]. Streaming responses
-//! use a per-chunk idle [`stream_idle_timeout`] that resets whenever a new SSE
-//! event arrives, so long generations are not cut off by a fixed wall-clock cap.
+//! Provider response duration is intentionally not bounded at this layer. A
+//! model may need an arbitrarily long time to load or generate output, while
+//! transport failures are reported by the HTTP/SSE stream and requests can be
+//! cancelled by the owning turn.
 
 use std::time::Duration;
 
-use futures::StreamExt;
-use reqwest_eventsource::{Event, EventSource};
-
-use crate::error::ProviderError;
-
-/// Total wall-clock timeout for non-streaming provider HTTP requests.
-pub const REQUEST_TIMEOUT_SECS: u64 = 120;
-
-/// TCP/TLS connect timeout for provider HTTP clients.
+/// TCP/TLS connection timeout for provider HTTP clients.
 pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 
-/// Maximum idle time between consecutive SSE events during streaming.
-pub const STREAM_IDLE_TIMEOUT_SECS: u64 = 60;
-
-/// Total timeout for non-streaming provider HTTP requests.
-#[inline]
-pub fn request_timeout() -> Duration {
-    Duration::from_secs(REQUEST_TIMEOUT_SECS)
-}
-
-/// TCP/TLS connect timeout for provider HTTP clients.
+/// TCP/TLS connection timeout for provider HTTP clients.
 #[inline]
 pub fn connect_timeout() -> Duration {
     Duration::from_secs(CONNECT_TIMEOUT_SECS)
-}
-
-/// Idle timeout between consecutive SSE events during streaming.
-#[inline]
-pub fn stream_idle_timeout() -> Duration {
-    Duration::from_secs(STREAM_IDLE_TIMEOUT_SECS)
-}
-
-/// Waits for the next SSE event, failing when no data arrives within
-/// [`stream_idle_timeout`].
-pub async fn next_eventsource_event(
-    event_source: &mut EventSource,
-) -> Result<Option<Result<Event, reqwest_eventsource::Error>>, StreamIdleTimeoutError> {
-    match tokio::time::timeout(stream_idle_timeout(), event_source.next()).await {
-        Ok(event) => Ok(event),
-        Err(_) => Err(StreamIdleTimeoutError {
-            idle_timeout: stream_idle_timeout(),
-        }),
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StreamIdleTimeoutError {
-    pub idle_timeout: Duration,
-}
-
-impl std::fmt::Display for StreamIdleTimeoutError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            formatter,
-            "provider stream idle timeout after {}s without receiving data",
-            self.idle_timeout.as_secs()
-        )
-    }
-}
-
-impl std::error::Error for StreamIdleTimeoutError {}
-
-/// Maps a stream idle timeout into a retryable [`ProviderError::ProviderTimeoutError`].
-pub fn stream_idle_timeout_provider_error(
-    provider_name: &str,
-    model: &str,
-    idle: StreamIdleTimeoutError,
-) -> ProviderError {
-    ProviderError::ProviderTimeoutError {
-        message: format!("{provider_name} stream idle timeout for model {model}: {idle}"),
-        provider_name: Some(provider_name.to_string()),
-    }
 }
 
 #[cfg(test)]
@@ -87,43 +23,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn request_timeout_is_two_minutes() {
-        assert_eq!(request_timeout(), Duration::from_secs(120));
-    }
-
-    #[test]
     fn connect_timeout_is_thirty_seconds() {
         assert_eq!(connect_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn stream_idle_timeout_is_one_minute() {
-        assert_eq!(stream_idle_timeout(), Duration::from_secs(60));
-    }
-
-    #[test]
-    fn stream_idle_timeout_maps_to_provider_timeout_error() {
-        let error = stream_idle_timeout_provider_error(
-            "openai",
-            "gpt-test",
-            StreamIdleTimeoutError {
-                idle_timeout: stream_idle_timeout(),
-            },
-        );
-        assert!(error.is_recoverable());
-        assert!(error.is_transient());
-        match error {
-            ProviderError::ProviderTimeoutError {
-                message,
-                provider_name,
-            } => {
-                assert_eq!(
-                    message,
-                    "openai stream idle timeout for model gpt-test: provider stream idle timeout after 60s without receiving data"
-                );
-                assert_eq!(provider_name.as_deref(), Some("openai"));
-            }
-            other => panic!("expected ProviderTimeoutError, got {other:?}"),
-        }
     }
 }

--- a/crates/server/src/runtime/provider_vendor_api.rs
+++ b/crates/server/src/runtime/provider_vendor_api.rs
@@ -15,7 +15,6 @@ use devo_provider::anthropic::AnthropicProvider;
 use devo_provider::openai::OpenAIProvider;
 use devo_provider::openai::OpenAIResponsesProvider;
 use devo_util_paths::current_user_config_file;
-use std::time::Duration;
 
 use crate::ProtocolErrorCode;
 use crate::SuccessResponse;
@@ -227,18 +226,14 @@ async fn validate_provider_candidate(
         )?,
     )?;
 
-    tokio::time::timeout(
-        Duration::from_secs(20),
-        test_model_connection(
-            provider.as_ref(),
-            &validation_model,
-            model_profile,
-            &params.model_binding.request_model,
-            "Reply with OK only.",
-        ),
+    test_model_connection(
+        provider.as_ref(),
+        &validation_model,
+        model_profile,
+        &params.model_binding.request_model,
+        "Reply with OK only.",
     )
     .await
-    .context("provider validation timed out after 20s")?
     .map_err(Into::into)
 }
 

--- a/crates/tui/src/bottom_pane/command_popup.rs
+++ b/crates/tui/src/bottom_pane/command_popup.rs
@@ -180,14 +180,13 @@ impl CommandPopup {
         matches
             .into_iter()
             .enumerate()
-            .map(|(idx, (item, indices))| {
+            .map(|(_, (item, indices))| {
                 let CommandItem::Builtin(cmd) = item;
                 let name = format!("/{}", cmd.command());
                 let description = cmd.description().to_string();
-                let selected = self.state.selected_idx == Some(idx);
                 GenericDisplayRow {
                     name,
-                    name_prefix_spans: vec![if selected { "> " } else { "  " }.into()],
+                    name_prefix_spans: vec!["  ".into()],
                     match_indices: indices.map(|v| v.into_iter().map(|i| i + 1).collect()),
                     display_shortcut: None,
                     description: Some(description),
@@ -338,6 +337,17 @@ mod tests {
             height >= MAX_POPUP_ROWS as u16,
             "expected filtered slash popup to keep an 8-row panel, got {height}"
         );
+    }
+
+    #[test]
+    fn selected_command_does_not_show_selection_marker() {
+        let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
+        popup.on_composer_text_change("/model".to_string());
+
+        let height = popup.calculate_required_height(80);
+        let rendered = render_popup(&popup, 80, height);
+
+        assert!(rendered.contains("  /model"));
     }
 
     #[test]

--- a/crates/tui/src/bottom_pane/command_popup.rs
+++ b/crates/tui/src/bottom_pane/command_popup.rs
@@ -186,7 +186,7 @@ impl CommandPopup {
                 let description = cmd.description().to_string();
                 GenericDisplayRow {
                     name,
-                    name_prefix_spans: vec!["  ".into()],
+                    name_prefix_spans: Vec::new(),
                     match_indices: indices.map(|v| v.into_iter().map(|i| i + 1).collect()),
                     display_shortcut: None,
                     description: Some(description),
@@ -340,14 +340,14 @@ mod tests {
     }
 
     #[test]
-    fn selected_command_does_not_show_selection_marker() {
+    fn selected_command_has_no_left_padding() {
         let mut popup = CommandPopup::new(CommandPopupFlags::default(), Color::Cyan);
         popup.on_composer_text_change("/model".to_string());
 
         let height = popup.calculate_required_height(80);
         let rendered = render_popup(&popup, 80, height);
 
-        assert!(rendered.contains("  /model"));
+        assert!(rendered.lines().any(|line| line.starts_with("  /model")));
     }
 
     #[test]

--- a/crates/tui/src/chatwidget/input.rs
+++ b/crates/tui/src/chatwidget/input.rs
@@ -757,6 +757,12 @@ impl ChatWidget {
     pub(crate) fn is_onboarding_active(&self) -> bool {
         self.onboarding.is_some()
     }
+
+    pub(crate) fn is_onboarding_validating(&self) -> bool {
+        self.onboarding
+            .as_ref()
+            .is_some_and(crate::onboarding_widget::OnboardingWidget::is_validating)
+    }
 }
 
 fn input_items_for_user_message(user_message: &UserMessage) -> Vec<InputItem> {

--- a/crates/tui/src/chatwidget/render.rs
+++ b/crates/tui/src/chatwidget/render.rs
@@ -132,7 +132,7 @@ impl ChatWidget {
             if self.bottom_pane.is_resume_picker_open() {
                 area.height.saturating_sub(3).max(3)
             } else {
-                area.height.saturating_sub(1).max(3)
+                area.height
             },
         );
         let subagent_height = self

--- a/crates/tui/src/chatwidget_layout_tests.rs
+++ b/crates/tui/src/chatwidget_layout_tests.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use devo_protocol::Model;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use tokio::sync::mpsc;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::chatwidget::ChatWidget;
+use crate::chatwidget::ChatWidgetInit;
+use crate::chatwidget::TuiSessionState;
+use crate::render::renderable::Renderable;
+use crate::tui::frame_requester::FrameRequester;
+
+fn widget() -> ChatWidget {
+    let (app_event_tx, _app_event_rx) = mpsc::unbounded_channel::<AppEvent>();
+    ChatWidget::new_with_app_event(ChatWidgetInit {
+        frame_requester: FrameRequester::test_dummy(),
+        app_event_tx: AppEventSender::new(app_event_tx),
+        initial_session: TuiSessionState::new(PathBuf::from("."), Some(Model::default())),
+        initial_reasoning_effort_selection: None,
+        initial_permission_preset: devo_protocol::PermissionPreset::Default,
+        initial_sandbox_profile: Some("workspace".to_string()),
+        initial_compaction_token_limit: None,
+        initial_default_collaboration_mode: devo_protocol::CollaborationMode::Build,
+        initial_user_message: None,
+        enhanced_keys_supported: true,
+        is_first_run: false,
+        available_models: Vec::new(),
+        saved_models: Vec::new(),
+        show_model_onboarding: false,
+        exit_after_onboarding: false,
+        startup_tooltip_override: None,
+        initial_theme_name: None,
+        initial_collapse_reasoning: false,
+    })
+}
+
+#[test]
+fn composer_footer_is_kept_at_content_height_for_single_and_wrapped_drafts() {
+    for draft in ["draft", "first line\nsecond line"] {
+        let mut widget = widget();
+        let bottom_pane = widget.bottom_pane_mut_for_test();
+        bottom_pane.set_text_content(draft.to_string(), Vec::new(), Vec::new());
+        bottom_pane.set_status_line(Some(Line::from("status sentinel")));
+        bottom_pane.set_status_line_enabled(true);
+
+        let width = 80;
+        let height = widget.desired_height(width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(area);
+        widget.render(area, &mut buffer);
+
+        let rendered = (0..area.height)
+            .map(|row| {
+                (0..area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rendered.iter().any(|row| row.contains("status sentinel")),
+            "status line disappeared for draft {draft:?}: {rendered:?}"
+        );
+    }
+}

--- a/crates/tui/src/interactive.rs
+++ b/crates/tui/src/interactive.rs
@@ -589,6 +589,10 @@ fn handle_tui_event(
             );
         }
         TuiEvent::Key(key) => {
+            if key.code == KeyCode::Esc && chat_widget.is_onboarding_validating() {
+                worker.cancel_provider_validation();
+                loop_state.pending_onboarding = None;
+            }
             if chat_widget.handle_onboarding_key_event(key) {
                 return Ok(LoopAction::Continue);
             }

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -10,6 +10,8 @@ mod app_event_sender;
 mod bottom_pane;
 mod chatwidget;
 #[cfg(test)]
+mod chatwidget_layout_tests;
+#[cfg(test)]
 mod chatwidget_tail_follow_tests;
 #[cfg(test)]
 mod chatwidget_tests;

--- a/crates/tui/src/onboarding_widget.rs
+++ b/crates/tui/src/onboarding_widget.rs
@@ -332,6 +332,10 @@ impl OnboardingWidget {
         self.complete
     }
 
+    pub(crate) fn is_validating(&self) -> bool {
+        matches!(&self.state, OnboardingState::Validating { .. })
+    }
+
     pub(crate) fn cancel(&mut self) {
         self.complete = true;
         self.result = Some(OnboardingResult::Cancelled);

--- a/crates/tui/src/worker.rs
+++ b/crates/tui/src/worker.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::Instant;
@@ -15,6 +17,7 @@ use devo_client::{ClientEvent, client_event_from_notification};
 use tokio::sync::mpsc;
 use tokio::task::JoinError;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use devo_core::PermissionPreset;
 use devo_core::ProviderWireApi;
@@ -441,10 +444,37 @@ fn next_shell_command_exec_start(
     }
 }
 
+#[derive(Default)]
+struct ProviderValidationCancellation(Mutex<Option<CancellationToken>>);
+
+impl ProviderValidationCancellation {
+    fn cancel(&self) {
+        if let Some(token) = self
+            .0
+            .lock()
+            .expect("provider validation cancellation mutex should not be poisoned")
+            .as_ref()
+        {
+            token.cancel();
+        }
+    }
+
+    fn start(&self) -> CancellationToken {
+        let token = CancellationToken::new();
+        *self
+            .0
+            .lock()
+            .expect("provider validation cancellation mutex should not be poisoned") =
+            Some(token.clone());
+        token
+    }
+}
+
 /// Handle used by the UI thread to interact with the background query worker.
 pub(crate) struct QueryWorkerHandle {
     /// Sender used to submit commands to the worker.
     command_tx: mpsc::UnboundedSender<OperationCommand>,
+    provider_validation_cancel: Arc<ProviderValidationCancellation>,
     /// Receiver used by the UI to consume worker events.
     pub(crate) event_rx: mpsc::UnboundedReceiver<WorkerEvent>,
     /// Background task running the worker loop.
@@ -456,9 +486,16 @@ impl QueryWorkerHandle {
     pub(crate) fn spawn(config: QueryWorkerConfig) -> Self {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let join_handle = tokio::spawn(run_worker(config, command_rx, event_tx));
+        let provider_validation_cancel = Arc::new(ProviderValidationCancellation::default());
+        let join_handle = tokio::spawn(run_worker(
+            config,
+            command_rx,
+            event_tx,
+            Arc::clone(&provider_validation_cancel),
+        ));
         Self {
             command_tx,
+            provider_validation_cancel,
             event_rx,
             join_handle,
         }
@@ -584,6 +621,11 @@ impl QueryWorkerHandle {
                 api_key,
             })
             .map_err(|_| anyhow::anyhow!("interactive worker is no longer running"))
+    }
+
+    /// Cancels the in-flight provider validation probe, if any.
+    pub(crate) fn cancel_provider_validation(&self) {
+        self.provider_validation_cancel.cancel();
     }
 
     /// Requests the current configured provider vendors from the background worker.
@@ -941,6 +983,7 @@ impl QueryWorkerHandle {
         let (_event_tx, event_rx) = mpsc::unbounded_channel();
         Self {
             command_tx,
+            provider_validation_cancel: Arc::new(ProviderValidationCancellation::default()),
             event_rx,
             join_handle: tokio::spawn(async move { while command_rx.recv().await.is_some() {} }),
         }
@@ -951,8 +994,16 @@ async fn run_worker(
     config: QueryWorkerConfig,
     mut command_rx: mpsc::UnboundedReceiver<OperationCommand>,
     event_tx: mpsc::UnboundedSender<WorkerEvent>,
+    provider_validation_cancel: Arc<ProviderValidationCancellation>,
 ) {
-    if let Err(error) = run_worker_inner(config, &mut command_rx, &event_tx).await {
+    if let Err(error) = run_worker_inner(
+        config,
+        &mut command_rx,
+        &event_tx,
+        provider_validation_cancel,
+    )
+    .await
+    {
         let _ = event_tx.send(WorkerEvent::TurnFailed {
             message: error.to_string(),
             hint: None,
@@ -971,6 +1022,7 @@ async fn run_worker_inner(
     config: QueryWorkerConfig,
     command_rx: &mut mpsc::UnboundedReceiver<OperationCommand>,
     event_tx: &mpsc::UnboundedSender<WorkerEvent>,
+    provider_validation_cancel: Arc<ProviderValidationCancellation>,
 ) -> Result<()> {
     // The worker owns the server client and translates UI commands into server
     // calls, then turns server notifications back into lightweight UI events.
@@ -1370,24 +1422,26 @@ async fn run_worker_inner(
                         model_binding,
                         api_key,
                     }) => {
-                        match tokio::time::timeout(
-                            Duration::from_secs(25),
-                            client.provider_validate(
-                                devo_protocol::native::rpc_admin::ProviderValidateParams {
-                                    provider_vendor: provider_vendor.into(),
-                                    model_binding: model_binding.into(),
-                                    api_key,
-                                },
-                            ),
-                        )
-                        .await
-                        {
-                            Ok(Ok(result)) => {
+                        let cancellation = provider_validation_cancel.start();
+                        let validation = client.provider_validate(
+                            devo_protocol::native::rpc_admin::ProviderValidateParams {
+                                provider_vendor: provider_vendor.into(),
+                                model_binding: model_binding.into(),
+                                api_key,
+                            },
+                        );
+                        tokio::pin!(validation);
+                        let validation_result = tokio::select! {
+                            result = &mut validation => Some(result),
+                            _ = cancellation.cancelled() => None,
+                        };
+                        match validation_result {
+                            Some(Ok(result)) => {
                                 let _ = event_tx.send(WorkerEvent::ProviderValidationSucceeded {
                                     reply_preview: result.reply_preview,
                                 });
                             }
-                            Ok(Err(error)) => {
+                            Some(Err(error)) => {
                                 let message = error.to_string();
                                 let hint =
                                     devo_provider::recovery_hint_for_message(&message);
@@ -1396,16 +1450,7 @@ async fn run_worker_inner(
                                     hint,
                                 });
                             }
-                            Err(_) => {
-                                let message =
-                                    "provider validation request timed out".to_string();
-                                let hint =
-                                    devo_provider::recovery_hint_for_message(&message);
-                                let _ = event_tx.send(WorkerEvent::ProviderValidationFailed {
-                                    message,
-                                    hint,
-                                });
-                            }
+                            None => {}
                         }
                     }
                     Some(OperationCommand::ListProviderVendors) => {
@@ -6605,10 +6650,12 @@ fn map_worker_join_result(result: std::result::Result<(), JoinError>) -> Result<
 
 #[cfg(test)]
 mod tests {
+    use super::ProviderValidationCancellation;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use std::future::pending;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use devo_core::SessionId;
@@ -6693,6 +6740,7 @@ mod tests {
         let (_event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
         let worker = QueryWorkerHandle {
             command_tx,
+            provider_validation_cancel: Arc::new(ProviderValidationCancellation::default()),
             event_rx,
             join_handle: tokio::spawn(async {
                 pending::<()>().await;

--- a/specs/L2/app/L2-DES-APP-005-config-toml-schema.md
+++ b/specs/L2/app/L2-DES-APP-005-config-toml-schema.md
@@ -324,9 +324,12 @@ Required fields for an enabled provider:
 Optional fields:
 
 - `availability_status`: last known safe status such as `unknown`, `valid`, `auth_required`, or `unavailable`.
-- `timeout_ms`: provider request timeout.
-- `connect_timeout_ms`: provider connection timeout.
 - `headers`: JSON object encoded as a TOML string. Object keys are HTTP header names and object values must be strings.
+
+Provider response duration is not configured in TOML. Runtime requests keep an
+internal connection-establishment deadline, but model loading and generation
+have no application-level response deadline; the owning turn or user may cancel
+them.
 
 Provider ids are stable program-generated identifiers. Changing `name` must not change the provider id.
 


### PR DESCRIPTION
## Summary

- TUI: preserve the composer status footer when opening the slash command popup.
- TUI: remove the slash command selection marker and its leftover padding.
- Provider: remove per-provider response timeouts; rely on the existing recovery-hint flow instead of duplicating timeout handling.

## Test Plan

- cargo test for TUI and provider changes.
- Desktop provider settings tests updated for the timeout removal.