### PR TITLE
fix: make code search installation opt-in

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -75,10 +75,11 @@ Desktop 体験、terminal workflow、ランタイムの動作、ワークスペ�
   コンテキストウィンドウ使用量を表示します。
 - **軽量な Rust ランタイム** - Rust で構築され、メモリ使用量が小さく、コンパクトなローカルランタイムを備えます。
 - **組み込みセマンティックコード検索（MCP）** - 同梱のオプション MCP サーバー
-  （`code_search` / `devo-code-search-mcp`）。**既定では無効**です。ローカル CPU の
-  コード埋め込みモデルを実行し、dense retrieval と BM25 を組み合わせて、grep/find
-  のみのエージェントよりコード検索コンテキストを削減します。
-  `devo mcp enable code_search` または TUI `/mcps` で有効化します。
+  （`code_search` / `devo-code-search-mcp`）。**既定ではインストールも有効化もされません**。
+  ローカル CPU のコード埋め込みモデルを実行し、dense retrieval と BM25 を組み合わせて、
+  grep/find のみのエージェントよりコード検索コンテキストを削減します。
+  `--with-code-search` でインストールし、`devo mcp enable code_search` または TUI `/mcps`
+  で有効化します。
 
 ## 検証済みモデル
 
@@ -157,23 +158,23 @@ irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 オンラインインストーラーは `devo` を Devo home ディレクトリに配置し、高速なリポジトリ検索に使う
-`rg` sidecar をインストールします。また、`code_search` が使うローカルモデルの任意設定にも対応しています。
+`rg` sidecar をインストールします。既定では `code_search` MCP とローカルモデルをインストールしません。
 
 <details>
-<summary>任意: ローカルの <code>code_search</code> モデルを事前インストール</summary>
+<summary>任意: <code>code_search</code> MCP とローカルモデルをインストール</summary>
 
-インストール時に Hugging Face モデルをダウンロードしたい場合だけ使用してください。
+インストール時に code-search MCP と Hugging Face モデルをインストールしたい場合だけ使用してください。
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Windows:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ runtime behavior, and workspace execution under your control.
 - **Lightweight Rust runtime** - Built in Rust with low memory overhead and a
   compact local runtime.
 - **Built-in semantic code search (MCP)** - Optional bundled MCP server
-  (`code_search` / `devo-code-search-mcp`), **disabled by default**. Runs a
-  local CPU code-embedding model and combines dense retrieval with BM25 keyword
-  matching to reduce code-search context versus grep/find-only agents. Enable
-  with `devo mcp enable code_search` or TUI `/mcps`.
+  (`code_search` / `devo-code-search-mcp`), **not installed or enabled by
+  default**. Runs a local CPU code-embedding model and combines dense retrieval
+  with BM25 keyword matching to reduce code-search context versus grep/find-only
+  agents. Install it explicitly with `--with-code-search`, then enable it with
+  `devo mcp enable code_search` or TUI `/mcps`.
 
 ## Tested Models
 
@@ -164,25 +165,26 @@ Windows:
 irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-The online installer places `devo` under the Devo home directory, installs the
-`rg` sidecar used for fast repository search, and supports optional setup for
-the local model used by `code_search`.
+The online installer places `devo` under the Devo home directory and installs
+the `rg` sidecar used for fast repository search. It does not install the
+`code_search` MCP or its local model by default.
 
 <details>
-<summary>Optional: preinstall the local <code>code_search</code> model</summary>
+<summary>Optional: install the <code>code_search</code> MCP and local model</summary>
 
-Use this only if you want the Hugging Face model downloaded during installation.
+Use this only if you want the code-search MCP and its Hugging Face model
+installed during setup.
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Windows:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 </details>

--- a/README.ru.md
+++ b/README.ru.md
@@ -81,10 +81,10 @@ Devo предназначен для команд, которым нужен cod
 - **Легковесный Rust runtime** - Построен на Rust, с малым расходом памяти и
   компактным локальным runtime.
 - **Встроенный семантический поиск по коду (MCP)** - Опциональный bundled MCP
-  сервер (`code_search` / `devo-code-search-mcp`), **по умолчанию выключен**.
-  Запускает локальную CPU-модель эмбеддингов и сочетает dense retrieval с BM25,
-  сокращая контекст поиска по сравнению с агентами только на grep/find. Включите
-  через `devo mcp enable code_search` или TUI `/mcps`.
+  сервер (`code_search` / `devo-code-search-mcp`), **по умолчанию не устанавливается и
+  выключен**. Запускает локальную CPU-модель эмбеддингов и сочетает dense retrieval с BM25,
+  сокращая контекст поиска по сравнению с агентами только на grep/find. Установите через
+  `--with-code-search`, затем включите через `devo mcp enable code_search` или TUI `/mcps`.
 
 ## Проверенные модели
 
@@ -167,25 +167,25 @@ Windows:
 irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-Онлайн-установщик размещает `devo` в Devo home directory, устанавливает
-вспомогательный `rg` sidecar для быстрого поиска по репозиторию и поддерживает
-дополнительную настройку локальной модели, которую использует `code_search`.
+Онлайн-установщик размещает `devo` в Devo home directory и устанавливает
+вспомогательный `rg` sidecar для быстрого поиска по репозиторию. По умолчанию
+`code_search` MCP и его локальная модель не устанавливаются.
 
 <details>
-<summary>Необязательно: предварительно установить локальную модель <code>code_search</code></summary>
+<summary>Необязательно: установить <code>code_search</code> MCP и локальную модель</summary>
 
-Используйте это только если хотите скачать модель Hugging Face во время установки.
+Используйте это только если хотите установить code-search MCP и скачать модель Hugging Face во время установки.
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Windows:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 </details>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -70,9 +70,9 @@ Desktop 体验、终端工作流以及工作区执行边界的团队。
   和上下文窗口用量。
 - **轻量级 Rust 运行时** - 使用 Rust 构建，内存开销低，本地运行时紧凑。
 - **内置语义代码搜索（MCP）** - 可选的捆绑 MCP 服务器（`code_search` /
-  `devo-code-search-mcp`），**默认关闭**。在本地 CPU 上运行代码嵌入模型，并结合
-  密集检索与 BM25 关键词匹配，相比仅用 grep/find 的代理减少代码搜索上下文。用
-  `devo mcp enable code_search` 或 TUI `/mcps` 启用。
+  `devo-code-search-mcp`），**默认不安装且不启用**。在本地 CPU 上运行代码嵌入模型，
+  并结合密集检索与 BM25 关键词匹配，相比仅用 grep/find 的代理减少代码搜索上下文。
+  使用 `--with-code-search` 安装，再用 `devo mcp enable code_search` 或 TUI `/mcps` 启用。
 
 ## 已测试模型
 
@@ -147,24 +147,24 @@ Windows:
 irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-在线安装器会把 `devo` 放到 Devo home 目录下，安装用于快速仓库搜索的
-`rg` sidecar，并支持可选安装 `code_search` 使用的本地模型。
+在线安装器会把 `devo` 放到 Devo home 目录下，并安装用于快速仓库搜索的
+`rg` sidecar。默认不会安装 `code_search` MCP 或其本地模型。
 
 <details>
-<summary>可选：预安装本地 <code>code_search</code> 模型</summary>
+<summary>可选：安装 <code>code_search</code> MCP 和本地模型</summary>
 
-仅在希望安装阶段就下载 Hugging Face 模型时使用。
+仅在希望安装阶段就安装 code-search MCP 和下载 Hugging Face 模型时使用。
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Windows:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 </details>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -70,9 +70,9 @@ Desktop 體驗、終端機工作流以及工作區執行邊界的團隊。
   和上下文視窗用量。
 - **輕量級 Rust 執行階段** - 使用 Rust 建構，記憶體開銷低，本地執行階段緊湊。
 - **內建語義程式碼搜尋（MCP）** - 可選的捆綁 MCP 伺服器（`code_search` /
-  `devo-code-search-mcp`），**預設關閉**。在本地 CPU 執行程式碼嵌入模型，並結合
-  密集檢索與 BM25 關鍵字比對，相比僅用 grep/find 的代理減少程式碼搜尋上下文。用
-  `devo mcp enable code_search` 或 TUI `/mcps` 啟用。
+  `devo-code-search-mcp`），**預設不安裝且不啟用**。在本地 CPU 執行程式碼嵌入模型，
+  並結合密集檢索與 BM25 關鍵字比對，相比僅用 grep/find 的代理減少程式碼搜尋上下文。
+  使用 `--with-code-search` 安裝，再用 `devo mcp enable code_search` 或 TUI `/mcps` 啟用。
 
 ## 已測試模型
 
@@ -147,24 +147,24 @@ Windows:
 irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-線上安裝器會把 `devo` 放到 Devo home 目錄下，安裝用於快速儲存庫搜尋的
-`rg` sidecar，並支援可選安裝 `code_search` 使用的本地模型。
+線上安裝器會把 `devo` 放到 Devo home 目錄下，並安裝用於快速儲存庫搜尋的
+`rg` sidecar。預設不會安裝 `code_search` MCP 或其本地模型。
 
 <details>
-<summary>可選：預安裝本地 <code>code_search</code> 模型</summary>
+<summary>可選：安裝 <code>code_search</code> MCP 和本地模型</summary>
 
-僅在希望安裝階段就下載 Hugging Face 模型時使用。
+僅在希望安裝階段就安裝 code-search MCP 和下載 Hugging Face 模型時使用。
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Windows:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 </details>

--- a/apps/desktop/scripts/prepare-runtime.test.ts
+++ b/apps/desktop/scripts/prepare-runtime.test.ts
@@ -45,7 +45,6 @@ describe("prepare-runtime helpers", () => {
 		mkdirSync(targetDir, { recursive: true })
 		mkdirSync(desktopDir, { recursive: true })
 		writeFileSync(join(targetDir, "devo"), "")
-		writeFileSync(join(targetDir, "devo-code-search-mcp"), "")
 
 		expect(() =>
 			stageRuntime({
@@ -70,7 +69,6 @@ describe("prepare-runtime helpers", () => {
 		mkdirSync(releaseDir, { recursive: true })
 		writeFileSync(devoBin, "devo")
 		writeFileSync(rgBin, "rg")
-		writeFileSync(join(releaseDir, "devo-code-search-mcp"), "mcp")
 
 		stageRuntime({
 			desktopDir,
@@ -82,15 +80,40 @@ describe("prepare-runtime helpers", () => {
 
 		expect({
 			devo: readFileSync(join(desktopDir, "resources", "runtime", "bin", "devo"), "utf8"),
-			mcp: readFileSync(
-				join(desktopDir, "resources", "runtime", "bin", "devo-code-search-mcp"),
-				"utf8",
-			),
 			rg: readFileSync(join(desktopDir, "resources", "runtime", "bin", "rg"), "utf8"),
+			mcp: existsSync(join(desktopDir, "resources", "runtime", "bin", "devo-code-search-mcp")),
 		}).toEqual({
 			devo: "devo",
-			mcp: "mcp",
 			rg: "rg",
+			mcp: false,
 		})
+	})
+
+	test("stages the optional code search MCP sidecar when requested", () => {
+		const root = mkdtempSync(join(tmpdir(), "devo-runtime-test-"))
+		const desktopDir = join(root, "desktop")
+		const sourceDir = join(root, "source")
+		const releaseDir = join(root, "target", "release")
+		const devoBin = join(sourceDir, "devo")
+		const rgBin = join(sourceDir, "rg")
+		const mcpBin = join(releaseDir, "devo-code-search-mcp")
+		mkdirSync(sourceDir, { recursive: true })
+		mkdirSync(releaseDir, { recursive: true })
+		writeFileSync(devoBin, "devo")
+		writeFileSync(rgBin, "rg")
+		writeFileSync(mcpBin, "mcp")
+
+		stageRuntime({
+			desktopDir,
+			repoRoot: root,
+			platform: "darwin",
+			devoBin,
+			rgBin,
+			withCodeSearch: true,
+		})
+
+		expect(readFileSync(join(desktopDir, "resources", "runtime", "bin", "devo-code-search-mcp"), "utf8")).toBe(
+			"mcp",
+		)
 	})
 })

--- a/apps/desktop/scripts/prepare-runtime.ts
+++ b/apps/desktop/scripts/prepare-runtime.ts
@@ -15,6 +15,7 @@ interface StageRuntimeOptions extends DefaultSourcePathOptions {
 	hostArch?: NodeJS.Architecture
 	hostPlatform?: NodeJS.Platform
 	rgBin?: string
+	withCodeSearch?: boolean
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -60,7 +61,8 @@ export function defaultCodeSearchMcpSourcePath({
 
 export function stageRuntime(options: StageRuntimeOptions): void {
 	const devoSource = options.devoBin ?? defaultDevoSourcePath(options)
-	const codeSearchMcpSource = defaultCodeSearchMcpSourcePath(options)
+	const withCodeSearch = options.withCodeSearch ?? false
+	const codeSearchMcpSource = withCodeSearch ? defaultCodeSearchMcpSourcePath(options) : undefined
 	const targetPlatform = platformForTargetTriple(options.targetTriple, options.platform ?? process.platform)
 	const rgOverride = options.rgBin ?? optionalPath(process.env.DEVO_DESKTOP_RUNTIME_RG_BIN)
 
@@ -88,7 +90,7 @@ export function stageRuntime(options: StageRuntimeOptions): void {
 	if (!existsSync(devoSource)) {
 		throw new Error(`Devo runtime binary not found at ${devoSource}`)
 	}
-	if (!existsSync(codeSearchMcpSource)) {
+	if (codeSearchMcpSource && !existsSync(codeSearchMcpSource)) {
 		throw new Error(`code_search MCP binary not found at ${codeSearchMcpSource}`)
 	}
 	if (!rgSource || !existsSync(rgSource)) {
@@ -100,17 +102,19 @@ export function stageRuntime(options: StageRuntimeOptions): void {
 	mkdirSync(runtimeBinDir, { recursive: true })
 
 	const devoDest = join(runtimeBinDir, runtimeBinaryName("devo", targetPlatform))
-	const codeSearchMcpDest = join(
-		runtimeBinDir,
-		runtimeBinaryName("devo-code-search-mcp", targetPlatform),
-	)
 	const rgDest = join(runtimeBinDir, runtimeBinaryName("rg", targetPlatform))
 	copyExecutable(devoSource, devoDest, targetPlatform)
-	copyExecutable(codeSearchMcpSource, codeSearchMcpDest, targetPlatform)
 	copyExecutable(rgSource, rgDest, targetPlatform)
+	if (codeSearchMcpSource) {
+		const codeSearchMcpDest = join(
+			runtimeBinDir,
+			runtimeBinaryName("devo-code-search-mcp", targetPlatform),
+		)
+		copyExecutable(codeSearchMcpSource, codeSearchMcpDest, targetPlatform)
+		console.log(`Prepared code_search MCP sidecar: ${codeSearchMcpDest}`)
+	}
 
 	console.log(`Prepared Desktop runtime: ${devoDest}`)
-	console.log(`Prepared code_search MCP sidecar: ${codeSearchMcpDest}`)
 	console.log(`Prepared ripgrep sidecar: ${rgDest}`)
 }
 
@@ -165,5 +169,6 @@ if (import.meta.main) {
 		platform: process.platform,
 		devoBin: argValue("--devo-bin") ?? optionalPath(process.env.DEVO_DESKTOP_RUNTIME_DEVO_BIN),
 		rgBin: argValue("--rg-bin"),
+		withCodeSearch: process.argv.includes("--with-code-search"),
 	})
 }

--- a/apps/web/content/docs/core-concepts/code-search.mdx
+++ b/apps/web/content/docs/core-concepts/code-search.mdx
@@ -55,9 +55,10 @@ Production code search uses a local model2vec embedding provider with the
 call.
 
 If the model files are missing, the MCP server tries to fetch them on first use.
-In an offline environment, pre-populate the local model cache before relying on
-`code_search`; otherwise the tool reports a recoverable model-unavailable
-configuration error.
+In an offline environment, install the optional code-search bundle with
+`--with-code-search` while preparing the machine, or pre-populate the local
+model cache manually before relying on `code_search`; otherwise the tool reports
+a recoverable configuration error.
 
 ## Cache Behavior
 

--- a/apps/web/content/docs/core-concepts/code-search.zh.mdx
+++ b/apps/web/content/docs/core-concepts/code-search.zh.mdx
@@ -37,7 +37,7 @@ Search 可按 path、content kind（`code` / `docs` / `config` / `all`）、lang
 
 ## 本地模型
 
-生产环境使用本地 model2vec embedding：`minishlab/potion-code-16M`，首次 embedding 时懒加载。离线环境需预先安装模型缓存（`install.sh --install-code-search-model`）。
+生产环境使用本地 model2vec embedding：`minishlab/potion-code-16M`，首次 embedding 时懒加载。离线环境需在准备机器时使用 `--with-code-search` 安装可选 code-search bundle，或手动预先安装模型缓存。
 
 ## 何时使用
 

--- a/apps/web/content/docs/get-started/install.mdx
+++ b/apps/web/content/docs/get-started/install.mdx
@@ -4,9 +4,9 @@ description: Install Devo online, from source, or in an offline environment.
 ---
 
 Devo installs as a user-local binary. The installer also installs the `rg`
-sidecar used by fast repository search. If you want local semantic
-`code_search`, install the small local model during setup or use the offline
-asset bundle described below.
+sidecar used by fast repository search. The optional `code_search` MCP and its
+local model are not installed by default. Use `--with-code-search` when you
+want both installed during setup.
 
 ## Linux And macOS
 
@@ -22,10 +22,10 @@ Install a specific release:
 curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --version v0.1.2
 ```
 
-Install the local `code_search` model at the same time:
+Install the `code_search` MCP and local model at the same time:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 The Unix installer accepts these options:
@@ -35,6 +35,7 @@ The Unix installer accepts these options:
 | `--version <version>` | Pin the Devo release instead of installing the latest release. |
 | `--binary <path>` | Install a local `devo` binary instead of downloading a release archive. |
 | `--install-dir <dir>` | Install into a custom directory. |
+| `--with-code-search` | Install the `code_search` MCP and local model. |
 | `--install-code-search-model` | Download the local Hugging Face model used by `code_search`. |
 | `--offline` | Install from files placed next to `install.sh`. |
 | `--no-modify-path` | Skip shell profile updates. |
@@ -46,6 +47,7 @@ Useful environment variables:
 | `VERSION` | Same as `--version`. |
 | `DEVO_INSTALL_DIR` | Same as `--install-dir`. |
 | `DEVO_SKIP_RG_INSTALL=1` | Skip installing the bundled `rg` sidecar. |
+| `DEVO_INSTALL_CODE_SEARCH=1` | Install the `code_search` MCP and local model. |
 | `DEVO_INSTALL_CODE_SEARCH_MODEL=1` | Same as `--install-code-search-model`. |
 
 ## Windows
@@ -62,10 +64,10 @@ Install a specific release:
 $env:VERSION = "v0.1.2"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-Install the local `code_search` model at the same time:
+Install the `code_search` MCP and local model at the same time:
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 The Windows installer installs to the current user's local program directory
@@ -103,7 +105,7 @@ replace the running `devo.exe` while the current process still owns the file.
 ## Install Without Internet Access
 
 Use offline installation for enterprise machines, intranet hosts, or any
-machine that cannot reach GitHub and Hugging Face during setup.
+machine that cannot reach GitHub during setup.
 
 Prepare the files on a machine that has internet access, then move them to the
 target machine. Put every file next to the installer script.
@@ -116,7 +118,6 @@ Download sources:
 | Windows installer | `https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1` |
 | Devo release archive | `https://github.com/7df-lab/devo/releases` |
 | ripgrep release archive | `https://github.com/BurntSushi/ripgrep/releases` |
-| `code_search` model files | `https://huggingface.co/minishlab/potion-code-16M/tree/main` |
 
 Required files for Linux and macOS:
 
@@ -125,7 +126,6 @@ Required files for Linux and macOS:
 | Installer | `install.sh` |
 | Devo release archive or binary | `devo-*-${target}.tar.gz` or `devo` |
 | ripgrep archive or binary | `ripgrep-*-${rg_target}.tar.gz` or `rg` |
-| `code_search` model files | `config.json`, `model.safetensors`, `tokenizer.json` |
 
 Required files for Windows:
 
@@ -134,13 +134,6 @@ Required files for Windows:
 | Installer | `install.ps1` |
 | Devo release archive or binary | `devo-*-${target}.zip` or `devo.exe` |
 | ripgrep archive or binary | `ripgrep-*-${rg_target}.zip` or `rg.exe` |
-| `code_search` model files | `config.json`, `model.safetensors`, `tokenizer.json` |
-
-The `code_search` files come from the `minishlab/potion-code-16M` Hugging Face
-model. They can sit next to the installer script directly, or under a
-`minishlab--potion-code-16M/` subdirectory. Offline installers currently install
-these model files unconditionally; they are the local semantic-search model used
-by `code_search`.
 
 ## Offline Bundle Targets
 
@@ -161,9 +154,6 @@ Silicon:
 install.sh
 devo-v0.1.2-aarch64-apple-darwin.tar.gz
 ripgrep-14.1.1-aarch64-apple-darwin.tar.gz
-minishlab--potion-code-16M/config.json
-minishlab--potion-code-16M/model.safetensors
-minishlab--potion-code-16M/tokenizer.json
 ```
 
 Example Windows bundle:
@@ -172,9 +162,6 @@ Example Windows bundle:
 install.ps1
 devo-v0.1.2-x86_64-pc-windows-msvc.zip
 ripgrep-14.1.1-x86_64-pc-windows-msvc.zip
-minishlab--potion-code-16M/config.json
-minishlab--potion-code-16M/model.safetensors
-minishlab--potion-code-16M/tokenizer.json
 ```
 
 Archive URL patterns:
@@ -184,9 +171,6 @@ https://github.com/7df-lab/devo/releases/download/<version>/devo-<version>-<targ
 https://github.com/7df-lab/devo/releases/download/<version>/devo-<version>-<target>.zip
 https://github.com/BurntSushi/ripgrep/releases/download/<rg_version>/ripgrep-<rg_version>-<rg_target>.tar.gz
 https://github.com/BurntSushi/ripgrep/releases/download/<rg_version>/ripgrep-<rg_version>-<rg_target>.zip
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/config.json
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/model.safetensors
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/tokenizer.json
 ```
 
 Run offline install on Linux or macOS:
@@ -199,12 +183,6 @@ Run offline install on Windows:
 
 ```powershell
 .\install.ps1 -Offline
-```
-
-Offline mode installs the model into:
-
-```text
-<DEVO_HOME>/local-models/minishlab--potion-code-16M
 ```
 
 If `DEVO_HOME` is not set, Devo uses the default user config directory:

--- a/apps/web/content/docs/get-started/install.zh.mdx
+++ b/apps/web/content/docs/get-started/install.zh.mdx
@@ -3,7 +3,9 @@ title: 安装
 description: 在线安装、源码构建或离线安装 Devo。
 ---
 
-Devo 以用户本地二进制形式安装。安装器也会安装 `rg` sidecar，用于快速仓库搜索。如果你需要本地语义 `code_search`，可以在安装时下载小型本地模型，或使用下面的离线资源包。
+Devo 以用户本地二进制形式安装。安装器也会安装 `rg` sidecar，用于快速仓库搜索。
+可选的 `code_search` MCP 和本地模型默认不会安装。需要时使用
+`--with-code-search` 在安装时同时安装。
 
 ## Linux 和 macOS
 
@@ -19,10 +21,10 @@ curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh
 curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --version v0.1.2
 ```
 
-同时安装本地 `code_search` 模型：
+同时安装 `code_search` MCP 和本地模型：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
+curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
 ```
 
 Unix 安装器支持：
@@ -32,6 +34,7 @@ Unix 安装器支持：
 | `--version <version>` | 固定 Devo 版本，而不是安装最新 release。 |
 | `--binary <path>` | 安装本地 `devo` 二进制，而不是下载 release archive。 |
 | `--install-dir <dir>` | 安装到自定义目录。 |
+| `--with-code-search` | 安装 `code_search` MCP 和本地模型。 |
 | `--install-code-search-model` | 下载 `code_search` 使用的本地 Hugging Face 模型。 |
 | `--offline` | 从 `install.sh` 旁边的文件离线安装。 |
 | `--no-modify-path` | 不更新 shell profile。 |
@@ -43,6 +46,7 @@ Unix 安装器支持：
 | `VERSION` | 等同于 `--version`。 |
 | `DEVO_INSTALL_DIR` | 等同于 `--install-dir`。 |
 | `DEVO_SKIP_RG_INSTALL=1` | 跳过内置 `rg` sidecar 安装。 |
+| `DEVO_INSTALL_CODE_SEARCH=1` | 安装 `code_search` MCP 和本地模型。 |
 | `DEVO_INSTALL_CODE_SEARCH_MODEL=1` | 等同于 `--install-code-search-model`。 |
 
 ## Windows
@@ -59,10 +63,10 @@ irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 $env:VERSION = "v0.1.2"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
-同时安装本地 `code_search` 模型：
+同时安装 `code_search` MCP 和本地模型：
 
 ```powershell
-$env:DEVO_INSTALL_CODE_SEARCH_MODEL = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
+$env:DEVO_INSTALL_CODE_SEARCH = "1"; irm 'https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1' | iex
 ```
 
 Windows 安装器会安装到当前用户的本地程序目录，并更新用户 `Path`。不需要管理员 shell。
@@ -96,7 +100,7 @@ Linux 和 macOS 上，`devo upgrade` 会下载并运行 `install.sh`。Windows �
 
 ## 无网络安装
 
-企业机器、内网主机或安装时不能访问 GitHub 和 Hugging Face 的机器，使用离线安装。
+企业机器、内网主机或安装时不能访问 GitHub 的机器，使用离线安装。
 
 先在有网络的机器上准备文件，再移动到目标机器。所有文件都放在安装脚本旁边。
 
@@ -108,7 +112,6 @@ Linux 和 macOS 上，`devo upgrade` 会下载并运行 `install.sh`。Windows �
 | Windows 安装器 | `https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1` |
 | Devo release archive | `https://github.com/7df-lab/devo/releases` |
 | ripgrep release archive | `https://github.com/BurntSushi/ripgrep/releases` |
-| `code_search` 模型文件 | `https://huggingface.co/minishlab/potion-code-16M/tree/main` |
 
 Linux 和 macOS 所需文件：
 
@@ -117,7 +120,6 @@ Linux 和 macOS 所需文件：
 | 安装器 | `install.sh` |
 | Devo release archive 或二进制 | `devo-*-${target}.tar.gz` 或 `devo` |
 | ripgrep archive 或二进制 | `ripgrep-*-${rg_target}.tar.gz` 或 `rg` |
-| `code_search` 模型文件 | `config.json`, `model.safetensors`, `tokenizer.json` |
 
 Windows 所需文件：
 
@@ -126,9 +128,6 @@ Windows 所需文件：
 | 安装器 | `install.ps1` |
 | Devo release archive 或二进制 | `devo-*-${target}.zip` 或 `devo.exe` |
 | ripgrep archive 或二进制 | `ripgrep-*-${rg_target}.zip` 或 `rg.exe` |
-| `code_search` 模型文件 | `config.json`, `model.safetensors`, `tokenizer.json` |
-
-`code_search` 文件来自 `minishlab/potion-code-16M` Hugging Face 模型。它们可以直接放在安装脚本旁边，也可以放在 `minishlab--potion-code-16M/` 子目录下。离线安装器当前会无条件安装这些模型文件；它们是 `code_search` 使用的本地语义搜索模型。
 
 ## 离线资源包 target
 
@@ -148,9 +147,6 @@ macOS Apple Silicon 上 Devo `v0.1.2` 和 ripgrep `14.1.1` 的 Unix 资源包示
 install.sh
 devo-v0.1.2-aarch64-apple-darwin.tar.gz
 ripgrep-14.1.1-aarch64-apple-darwin.tar.gz
-minishlab--potion-code-16M/config.json
-minishlab--potion-code-16M/model.safetensors
-minishlab--potion-code-16M/tokenizer.json
 ```
 
 Windows 资源包示例：
@@ -159,9 +155,6 @@ Windows 资源包示例：
 install.ps1
 devo-v0.1.2-x86_64-pc-windows-msvc.zip
 ripgrep-14.1.1-x86_64-pc-windows-msvc.zip
-minishlab--potion-code-16M/config.json
-minishlab--potion-code-16M/model.safetensors
-minishlab--potion-code-16M/tokenizer.json
 ```
 
 Archive URL 模式：
@@ -171,9 +164,6 @@ https://github.com/7df-lab/devo/releases/download/<version>/devo-<version>-<targ
 https://github.com/7df-lab/devo/releases/download/<version>/devo-<version>-<target>.zip
 https://github.com/BurntSushi/ripgrep/releases/download/<rg_version>/ripgrep-<rg_version>-<rg_target>.tar.gz
 https://github.com/BurntSushi/ripgrep/releases/download/<rg_version>/ripgrep-<rg_version>-<rg_target>.zip
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/config.json
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/model.safetensors
-https://huggingface.co/minishlab/potion-code-16M/resolve/main/tokenizer.json
 ```
 
 Linux 或 macOS 离线安装：
@@ -186,12 +176,6 @@ Windows 离线安装：
 
 ```powershell
 .\install.ps1 -Offline
-```
-
-离线模式会把模型安装到：
-
-```text
-<DEVO_HOME>/local-models/minishlab--potion-code-16M
 ```
 
 如果未设置 `DEVO_HOME`，Devo 使用默认用户配置目录：

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -628,8 +628,10 @@ edit TOML when you need transport details, env vars, or headers.
 
 ### Bundled `code_search` (disabled by default)
 
-Devo ships an optional semantic search MCP binary next to `devo`. The config
-entry is injected when missing and stays **disabled** until you enable it:
+Devo supports an optional semantic search MCP binary. It is **not installed or
+enabled by default**. Use the installer with `--with-code-search` to install
+the MCP binary and local model. The config entry is injected when missing and
+stays **disabled** until you enable it:
 
 ```toml
 [[mcp.servers]]
@@ -649,7 +651,8 @@ devo mcp enable code_search
 ```
 
 When enabled, the model-facing tool name is `mcp__code_search__code_search`.
-The `devo-code-search-mcp` binary is installed next to `devo`.
+If the `devo-code-search-mcp` binary is not installed, enabling the server will
+fail until you install the optional code-search bundle.
 
 ### CLI management
 

--- a/docs/configuration.zh-Hans.md
+++ b/docs/configuration.zh-Hans.md
@@ -536,7 +536,8 @@ Devo 通过用户或工作区 `config.toml` 中的 `[mcp]` 配置
 
 ### 捆绑的 `code_search`（默认关闭）
 
-Devo 会在 `devo` 旁边安装可选的语义搜索 MCP 二进制。配置项在缺失时会自动注入，
+Devo 支持可选的语义搜索 MCP 二进制。默认**不会安装或启用**。使用带有
+`--with-code-search` 的安装器可以安装 MCP 二进制和本地模型。配置项在缺失时会自动注入，
 且保持 **disabled**，直到你显式启用：
 
 ```toml
@@ -557,6 +558,7 @@ devo mcp enable code_search
 ```
 
 启用后，模型侧工具名为 `mcp__code_search__code_search`。
+如果 `devo-code-search-mcp` 尚未安装，启用服务会失败，需先安装可选的 code-search bundle。
 
 ### CLI 管理
 

--- a/docs/offline-installation.ja.md
+++ b/docs/offline-installation.ja.md
@@ -10,12 +10,9 @@ Devo のインストーラーはオフラインモードをサポートしてお
 1. インストーラースクリプトをダウンロードします。Linux/macOS は `install.sh`、Windows は `install.ps1` です。
 2. 対象 CPU と OS 向けの最新 Devo release asset をダウンロードします。例: `x86_64`
    と `aarch64`/`arm64`。
-3. ローカルセマンティック `code_search` が使う Hugging Face `minishlab/potion-code-16M`
-   モデルファイルをダウンロードします: `config.json`、`model.safetensors`、`tokenizer.json`。
-4. 対象 CPU と OS に合う `ripgrep` release asset をダウンロードします。
+3. 対象 CPU と OS に合う `ripgrep` release asset をダウンロードします。
 
-これらのファイルをインストーラースクリプトの隣に置きます。モデルファイルはスクリプトの隣に直接置いても、
-`minishlab--potion-code-16M/` サブディレクトリに置いても構いません。
+これらのファイルをインストーラースクリプトの隣に置きます。
 
 Linux / macOS:
 
@@ -28,9 +25,3 @@ Windows:
 ```powershell
 .\install.ps1 -Offline
 ```
-
-オフラインモードでは、モデルは
-`<DEVO_HOME>/local-models/minishlab--potion-code-16M` にインストールされます。
-これはランタイムの code-search provider が使用するディレクトリです。
-`DEVO_HOME` が設定されていない場合は
-`~/.devo/local-models/minishlab--potion-code-16M` になります。

--- a/docs/offline-installation.md
+++ b/docs/offline-installation.md
@@ -12,14 +12,9 @@ On a machine with internet access:
    for Windows.
 2. Download the latest Devo release asset for the target CPU and OS, for example
    `x86_64` vs `aarch64`/`arm64`.
-3. Download the Hugging Face `minishlab/potion-code-16M` model files used by
-   local semantic `code_search`: `config.json`, `model.safetensors`, and
-   `tokenizer.json`.
-4. Download the matching `ripgrep` release asset for the target CPU and OS.
+3. Download the matching `ripgrep` release asset for the target CPU and OS.
 
-Place these files next to the installer script. The model files can either sit
-next to the installer directly or under a `minishlab--potion-code-16M/`
-subdirectory.
+Place these files next to the installer script.
 
 Linux / macOS:
 
@@ -32,8 +27,3 @@ Windows:
 ```powershell
 .\install.ps1 -Offline
 ```
-
-Offline mode installs the model into
-`<DEVO_HOME>/local-models/minishlab--potion-code-16M`, which is the directory
-used by the runtime code-search provider. When `DEVO_HOME` is not set, this is
-`~/.devo/local-models/minishlab--potion-code-16M`.

--- a/docs/offline-installation.ru.md
+++ b/docs/offline-installation.ru.md
@@ -12,14 +12,9 @@ Devo поддерживают офлайн-режим: они читают вс�
    для Windows.
 2. Скачайте последний Devo release asset для целевой CPU и OS, например
    `x86_64` или `aarch64`/`arm64`.
-3. Скачайте файлы модели Hugging Face `minishlab/potion-code-16M`, которую
-   использует локальный семантический `code_search`: `config.json`,
-   `model.safetensors` и `tokenizer.json`.
-4. Скачайте соответствующий `ripgrep` release asset для целевой CPU и OS.
+3. Скачайте соответствующий `ripgrep` release asset для целевой CPU и OS.
 
-Положите эти файлы рядом со скриптом установщика. Файлы модели можно положить
-непосредственно рядом со скриптом или в подкаталог
-`minishlab--potion-code-16M/`.
+Положите эти файлы рядом со скриптом установщика.
 
 Linux / macOS:
 
@@ -32,8 +27,3 @@ Windows:
 ```powershell
 .\install.ps1 -Offline
 ```
-
-Офлайн-режим устанавливает модель в
-`<DEVO_HOME>/local-models/minishlab--potion-code-16M`; это каталог, который
-использует runtime code-search provider. Если `DEVO_HOME` не задан, путь будет
-`~/.devo/local-models/minishlab--potion-code-16M`.

--- a/docs/offline-installation.zh-Hans.md
+++ b/docs/offline-installation.zh-Hans.md
@@ -10,12 +10,9 @@
 1. 下载安装脚本：Linux/macOS 使用 `install.sh`，Windows 使用 `install.ps1`。
 2. 下载目标 CPU 和操作系统对应的最新 Devo release asset，例如 `x86_64`
    与 `aarch64`/`arm64`。
-3. 下载本地语义 `code_search` 使用的 Hugging Face `minishlab/potion-code-16M`
-   模型文件：`config.json`、`model.safetensors` 和 `tokenizer.json`。
-4. 下载目标 CPU 和操作系统对应的 `ripgrep` release asset。
+3. 下载目标 CPU 和操作系统对应的 `ripgrep` release asset。
 
-把这些文件放在安装脚本旁边。模型文件可以直接放在安装脚本旁边，也可以放在
-`minishlab--potion-code-16M/` 子目录下。
+把这些文件放在安装脚本旁边。
 
 Linux / macOS:
 
@@ -28,8 +25,3 @@ Windows:
 ```powershell
 .\install.ps1 -Offline
 ```
-
-离线模式会把模型安装到
-`<DEVO_HOME>/local-models/minishlab--potion-code-16M`，这是运行时
-code-search provider 使用的目录。如果没有设置 `DEVO_HOME`，该路径为
-`~/.devo/local-models/minishlab--potion-code-16M`。

--- a/docs/offline-installation.zh-Hant.md
+++ b/docs/offline-installation.zh-Hant.md
@@ -10,12 +10,9 @@
 1. 下載安裝腳本：Linux/macOS 使用 `install.sh`，Windows 使用 `install.ps1`。
 2. 下載目標 CPU 和作業系統對應的最新 Devo release asset，例如 `x86_64`
    與 `aarch64`/`arm64`。
-3. 下載本地語義 `code_search` 使用的 Hugging Face `minishlab/potion-code-16M`
-   模型檔案：`config.json`、`model.safetensors` 和 `tokenizer.json`。
-4. 下載目標 CPU 和作業系統對應的 `ripgrep` release asset。
+3. 下載目標 CPU 和作業系統對應的 `ripgrep` release asset。
 
-把這些檔案放在安裝腳本旁邊。模型檔案可以直接放在安裝腳本旁邊，也可以放在
-`minishlab--potion-code-16M/` 子目錄下。
+把這些檔案放在安裝腳本旁邊。
 
 Linux / macOS:
 
@@ -28,8 +25,3 @@ Windows:
 ```powershell
 .\install.ps1 -Offline
 ```
-
-離線模式會把模型安裝到
-`<DEVO_HOME>/local-models/minishlab--potion-code-16M`，這是執行階段
-code-search provider 使用的目錄。如果沒有設定 `DEVO_HOME`，該路徑為
-`~/.devo/local-models/minishlab--potion-code-16M`。

--- a/install.ps1
+++ b/install.ps1
@@ -6,11 +6,15 @@
 # Pin a specific version:
 #   $env:VERSION = "v0.1.2"; irm https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1 | iex
 #
+# Optional code-search bundle:
+#   $env:DEVO_INSTALL_CODE_SEARCH = "1"; irm https://raw.githubusercontent.com/7df-lab/devo/main/install.ps1 | iex
+#
 # Offline install from assets next to install.ps1:
 #   .\install.ps1 -Offline
 
 param(
     [string]$Version = $env:VERSION,
+    [switch]$WithCodeSearch,
     [switch]$InstallCodeSearchModel,
     [switch]$Offline
 )
@@ -174,7 +178,11 @@ function Test-Truthy {
 }
 
 function Should-InstallCodeSearchModel {
-    return $InstallCodeSearchModel -or (Test-Truthy $env:DEVO_INSTALL_CODE_SEARCH_MODEL)
+    return (Should-InstallCodeSearch) -or $InstallCodeSearchModel -or (Test-Truthy $env:DEVO_INSTALL_CODE_SEARCH_MODEL)
+}
+
+function Should-InstallCodeSearch {
+    return $WithCodeSearch -or (Test-Truthy $env:DEVO_INSTALL_CODE_SEARCH)
 }
 
 function Get-DevoHome {
@@ -420,6 +428,13 @@ function Install-DevoOffline {
         Write-Host "Installing devo from local binary: $localExe"
         New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
         Copy-Item -Path $localExe -Destination (Join-Path $InstallDir "devo.exe") -Force
+        if (Should-InstallCodeSearch) {
+            $localMcp = Join-Path $AssetDir "devo-code-search-mcp.exe"
+            if (-not (Test-Path $localMcp)) {
+                Write-Error "Requested code_search MCP binary not found at $localMcp"
+            }
+            Copy-Item -Path $localMcp -Destination (Join-Path $InstallDir "devo-code-search-mcp.exe") -Force
+        }
         return
     }
 
@@ -441,9 +456,11 @@ function Install-DevoOffline {
 
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
     Copy-Item -Path $exe.FullName -Destination (Join-Path $InstallDir "devo.exe") -Force
-
-    $mcpExe = Get-ChildItem -Recurse -Filter "devo-code-search-mcp.exe" -Path $devoTmpDir | Select-Object -First 1
-    if ($mcpExe) {
+    if (Should-InstallCodeSearch) {
+        $mcpExe = Get-ChildItem -Recurse -Filter "devo-code-search-mcp.exe" -Path $devoTmpDir | Select-Object -First 1
+        if (-not $mcpExe) {
+            Write-Error "Requested code_search MCP binary was not found in the offline archive"
+        }
         Copy-Item -Path $mcpExe.FullName -Destination (Join-Path $InstallDir "devo-code-search-mcp.exe") -Force
     }
 }
@@ -513,13 +530,17 @@ function Install-CodeSearchModelOffline {
         [string]$AssetDir
     )
 
+    if (-not (Should-InstallCodeSearchModel)) {
+        return
+    }
+
     $nestedModelDir = Join-Path $AssetDir $CodeSearchModelDirName
     if (Test-CodeSearchModelFiles -Directory $nestedModelDir) {
         $sourceDir = $nestedModelDir
     } elseif (Test-CodeSearchModelFiles -Directory $AssetDir) {
         $sourceDir = $AssetDir
     } else {
-        Write-Error "Offline code_search model files not found. Place config.json, model.safetensors, and tokenizer.json next to install.ps1 or under ${CodeSearchModelDirName}\."
+        Write-Error "Requested code_search model files were not found. Place config.json, model.safetensors, and tokenizer.json next to install.ps1 or under ${CodeSearchModelDirName}\."
     }
 
     $modelDir = Join-Path (Join-Path (Get-DevoHome) "local-models") $CodeSearchModelDirName
@@ -558,6 +579,12 @@ function Main {
             Write-VersionTransition -InstallDir $installDir -TargetVersion $version
 
             $skipAppInstall = Test-DevoVersionInstalled -InstallDir $installDir -ExpectedVersion $version
+            if ($skipAppInstall -and (Should-InstallCodeSearch)) {
+                $mcpPath = Join-Path $installDir "devo-code-search-mcp.exe"
+                if (-not (Test-Path $mcpPath)) {
+                    $skipAppInstall = $false
+                }
+            }
             if (-not $skipAppInstall) {
                 $archiveUrl = "https://github.com/$Repo/releases/download/$version/devo-${version}-${target}.zip"
 
@@ -577,12 +604,13 @@ function Main {
                 New-Item -ItemType Directory -Force -Path $installDir | Out-Null
                 Copy-Item -Path $exe.FullName -Destination (Join-Path $installDir "devo.exe") -Force
 
-                $mcpExe = Get-ChildItem -Recurse -Filter "devo-code-search-mcp.exe" -Path $tmpDir | Select-Object -First 1
-                if ($mcpExe) {
+                if (Should-InstallCodeSearch) {
+                    $mcpExe = Get-ChildItem -Recurse -Filter "devo-code-search-mcp.exe" -Path $tmpDir | Select-Object -First 1
+                    if (-not $mcpExe) {
+                        Write-Error "Requested code_search MCP binary was not found in the release archive"
+                    }
                     Copy-Item -Path $mcpExe.FullName -Destination (Join-Path $installDir "devo-code-search-mcp.exe") -Force
                     Write-Host "Installed code_search MCP sidecar"
-                } else {
-                    Write-Host "Optional devo-code-search-mcp.exe was not found in the archive."
                 }
             }
             Install-RipgrepSidecar -InstallDir $installDir -TempRoot $tmpDir
@@ -598,7 +626,7 @@ function Main {
         } else {
             Write-Host "ripgrep sidecar was not installed."
         }
-        if ($Offline -or (Should-InstallCodeSearchModel)) {
+        if (Should-InstallCodeSearchModel) {
             $modelPath = Join-Path (Join-Path (Get-DevoHome) "local-models") $CodeSearchModelDirName
             Write-Host "code_search model available at $modelPath"
         }

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ requested_version="${VERSION:-}"
 binary_path=""
 no_modify_path="false"
 offline_mode="false"
+with_code_search="${DEVO_INSTALL_CODE_SEARCH:-}"
 install_code_search_model="${DEVO_INSTALL_CODE_SEARCH_MODEL:-}"
 install_dir="${DEVO_INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
 skip_app_install="false"
@@ -42,6 +43,7 @@ Options:
     -v, --version <version> Install a specific version (for example: v0.1.2)
     -b, --binary <path>     Install from a local binary instead of downloading
         --install-dir <dir> Install into a custom directory
+        --with-code-search     Install the code_search MCP and local model
         --install-code-search-model
                             Download the local Hugging Face model used by code_search
         --offline           Install from assets placed next to install.sh without network access
@@ -51,12 +53,15 @@ Environment:
     VERSION                 Same as --version
     DEVO_INSTALL_DIR        Same as --install-dir
     DEVO_SKIP_RG_INSTALL=1 Skip installing the ripgrep sidecar
+    DEVO_INSTALL_CODE_SEARCH=1
+                            Install the code_search MCP and local model
     DEVO_INSTALL_CODE_SEARCH_MODEL=1
                             Download the local Hugging Face model used by code_search
 
 Examples:
     curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh
     curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --version v0.1.2
+    curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --with-code-search
     curl -fsSL https://raw.githubusercontent.com/7df-lab/devo/main/install.sh | sh -s -- --install-code-search-model
     sh ./install.sh --offline
     ./install.sh --binary ./target/release/devo
@@ -112,6 +117,10 @@ while [ "$#" -gt 0 ]; do
                 die "Error: --install-dir requires a directory argument"
             fi
             ;;
+        --with-code-search)
+            with_code_search="1"
+            shift
+            ;;
         --install-code-search-model)
             install_code_search_model="1"
             shift
@@ -148,7 +157,19 @@ is_truthy() {
 }
 
 should_install_code_search_model() {
+    if should_install_code_search; then
+        return 0
+    fi
+
     is_truthy "$install_code_search_model"
+}
+
+should_install_code_search() {
+    is_truthy "$with_code_search"
+}
+
+code_search_mcp_installed() {
+    [ -x "${install_dir}/${CODE_SEARCH_MCP_APP}" ]
 }
 
 normalize_version() {
@@ -451,7 +472,7 @@ check_version() {
         print_message info "${MUTED}${APP} ${NC}${expected_version}${MUTED} is already installed at ${NC}${installed_path}"
         skip_app_install="true"
         if [ "${DEVO_SKIP_RG_INSTALL:-}" = "1" ] || [ -x "${install_dir}/${RG_APP}" ]; then
-            if ! should_install_code_search_model; then
+            if ! should_install_code_search_model && { ! should_install_code_search || code_search_mcp_installed; }; then
                 exit 0
             fi
         else
@@ -460,6 +481,10 @@ check_version() {
 
         if should_install_code_search_model; then
             print_message info "${MUTED}code_search model install requested; continuing optional installation.${NC}"
+        fi
+        if should_install_code_search && ! code_search_mcp_installed; then
+            skip_app_install="false"
+            print_message info "${MUTED}code_search MCP install requested; continuing optional installation.${NC}"
         fi
         return
     fi
@@ -529,15 +554,16 @@ download_and_install() {
     tar -xzf "$tmp_dir/$archive_name" -C "$tmp_dir"
 
     extracted_binary="$(find_extracted_binary "$tmp_dir")"
-    extracted_mcp_binary="$(find_extracted_optional_binary "$tmp_dir" "$CODE_SEARCH_MCP_APP")"
 
     mkdir -p "$install_dir"
     install -m 755 "$extracted_binary" "${install_dir}/${APP}"
-    if [ -n "$extracted_mcp_binary" ]; then
+    if should_install_code_search; then
+        extracted_mcp_binary="$(find_extracted_optional_binary "$tmp_dir" "$CODE_SEARCH_MCP_APP")"
+        if [ -z "$extracted_mcp_binary" ]; then
+            die "Requested code_search MCP binary was not found in the release archive"
+        fi
         install -m 755 "$extracted_mcp_binary" "${install_dir}/${CODE_SEARCH_MCP_APP}"
         print_message info "${MUTED}Installed ${NC}${CODE_SEARCH_MCP_APP}${MUTED} sidecar${NC}"
-    else
-        print_message warning "Optional ${CODE_SEARCH_MCP_APP} binary was not found in the archive."
     fi
 
     rm -rf "$tmp_dir"
@@ -675,6 +701,13 @@ install_offline_devo() {
     if [ -f "${asset_dir}/${APP}" ]; then
         print_message info "${MUTED}Installing ${NC}${APP} ${MUTED}from local binary: ${NC}${asset_dir}/${APP}"
         install_from_binary "${asset_dir}/${APP}"
+        if should_install_code_search; then
+            local_mcp_binary="${asset_dir}/${CODE_SEARCH_MCP_APP}"
+            if [ ! -f "$local_mcp_binary" ]; then
+                die "Requested code_search MCP binary not found at ${local_mcp_binary}"
+            fi
+            install -m 755 "$local_mcp_binary" "${install_dir}/${CODE_SEARCH_MCP_APP}"
+        fi
         return
     fi
 
@@ -693,11 +726,13 @@ install_offline_devo() {
 
     tar -xzf "$archive_path" -C "$tmp_dir"
     extracted_binary="$(find_extracted_binary "$tmp_dir")"
-    extracted_mcp_binary="$(find_extracted_optional_binary "$tmp_dir" "$CODE_SEARCH_MCP_APP")"
-
     mkdir -p "$install_dir"
     install -m 755 "$extracted_binary" "${install_dir}/${APP}"
-    if [ -n "$extracted_mcp_binary" ]; then
+    if should_install_code_search; then
+        extracted_mcp_binary="$(find_extracted_optional_binary "$tmp_dir" "$CODE_SEARCH_MCP_APP")"
+        if [ -z "$extracted_mcp_binary" ]; then
+            die "Requested code_search MCP binary was not found in the offline archive"
+        fi
         install -m 755 "$extracted_mcp_binary" "${install_dir}/${CODE_SEARCH_MCP_APP}"
         print_message info "${MUTED}Installed ${NC}${CODE_SEARCH_MCP_APP}${MUTED} sidecar${NC}"
     fi
@@ -751,6 +786,10 @@ install_offline_ripgrep_sidecar() {
 }
 
 install_offline_code_search_model_files() {
+    if ! should_install_code_search_model; then
+        return
+    fi
+
     asset_dir="$1"
     model_dir="$(code_search_model_dir)"
     nested_model_dir="${asset_dir}/${CODE_SEARCH_MODEL_DIR_NAME}"
@@ -760,7 +799,7 @@ install_offline_code_search_model_files() {
     elif code_search_model_files_present "$asset_dir"; then
         source_dir="$asset_dir"
     else
-        die "Offline code_search model files not found. Place ${CODE_SEARCH_MODEL_FILES} next to install.sh or under ${CODE_SEARCH_MODEL_DIR_NAME}/."
+        die "Requested code_search model files were not found. Place ${CODE_SEARCH_MODEL_FILES} next to install.sh or under ${CODE_SEARCH_MODEL_DIR_NAME}/."
     fi
 
     mkdir -p "$model_dir"
@@ -775,7 +814,6 @@ install_offline_code_search_model_files() {
     fi
 }
 
-
 print_banner() {
     printf '\n'
     printf '%b%s%b\n' "$MUTED" "██████╗  ███████╗██╗   ██╗ ██████╗" "$NC"
@@ -789,6 +827,10 @@ print_banner() {
 
 main() {
     print_banner
+
+    if should_install_code_search && [ -n "$binary_path" ]; then
+        die "--with-code-search requires a release archive so the MCP binary can be installed"
+    fi
 
     if [ "$offline_mode" = "true" ]; then
         asset_dir="$(installer_asset_dir)"


### PR DESCRIPTION
## Summary\n- make code-search MCP and model installation opt-in for CLI installers\n- keep offline installation limited to Devo and ripgrep by default\n- make desktop runtime code-search staging optional\n- synchronize installation and configuration documentation\n\n## Validation\n- Bash syntax check passed\n- PowerShell parser check passed\n- targeted TypeScript check for prepare-runtime passed\n- Bun desktop test not run because Bun is unavailable in the local environment